### PR TITLE
golang.org/x/term v0.5.0 -> v0.12.0 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/99designs/keyring v1.2.2
 	github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	golang.org/x/term v0.5.0
+	golang.org/x/term v0.12.0
 	google.golang.org/protobuf v1.28.1
 )
 


### PR DESCRIPTION
Updated outdated library SCA scanned, just a little update. 

https://sca.analysiscenter.veracode.com/vulnerability-database/search#query=3458047

SRCCLR-LID-3458047