### PR TITLE
Add optional TLS configuration for `tesla-http-proxy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ openssl req -x509 -nodes -newkey ec -pkeyopt ec_paramgen_curve:secp521r1 \
 
 This command creates an unencrypted private key, `key.pem`.
 
+*Note:* To skip the above key generation, pass the `-skip-tls` flag. This will allow you to run the server without creating a TLS key and certificate.
+
 ### Running the proxy server
 
 You can start the proxy server using the following command:
@@ -200,6 +202,8 @@ tesla-http-proxy -tls-key key.pem -cert cert.pem -port 4443
 
 *Note:* In production, you'll likely want to omit the `-port 4443` and listen on
 the standard port 443.
+
+
 
 ### Sending commands to the proxy server
 

--- a/cmd/tesla-http-proxy/main.go
+++ b/cmd/tesla-http-proxy/main.go
@@ -43,6 +43,7 @@ func main() {
 		verbose      bool
 		host         string
 		port         int
+		skipTLS      bool
 	)
 	config := cli.Config{Flags: cli.FlagPrivateKey}
 	var err error
@@ -58,6 +59,7 @@ func main() {
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
 	flag.StringVar(&host, "host", "localhost", "Proxy server `hostname`")
 	flag.IntVar(&port, "port", defaultPort, "`Port` to listen on")
+	flag.BoolVar(&skipTLS, "skip-tls", false, "Skip TLS and serve HTTP only")
 	flag.Usage = Usage
 	config.RegisterCommandLineFlags()
 	flag.Parse()
@@ -94,10 +96,16 @@ func main() {
 	addr := fmt.Sprintf("%s:%d", host, port)
 	log.Info("Listening on %s", addr)
 
-	// To add more application logic requests, such as alternative client authentication, create
-	// a http.HandleFunc implementation (https://pkg.go.dev/net/http#HandlerFunc). The ServeHTTP
-	// method of your implementation can perform your business logic and then, if the request is
-	// authorized, invoke p.ServeHTTP. Finally, replace p in the below ListenAndServeTLS call with
-	// an object of your newly created type.
-	log.Error("Server stopped: %s", http.ListenAndServeTLS(addr, certFilename, keyFilename, p))
+	if skipTLS {
+		log.Info("TLS is disabled. Serving HTTP only.")
+		log.Error("Server stopped: %s", http.ListenAndServe(addr, p))
+	} else {
+		// Your existing TLS setup and server start code
+		// To add more application logic requests, such as alternative client authentication, create
+		// a http.HandleFunc implementation (https://pkg.go.dev/net/http#HandlerFunc). The ServeHTTP
+		// method of your implementation can perform your business logic and then, if the request is
+		// authorized, invoke p.ServeHTTP. Finally, replace p in the below ListenAndServeTLS call with
+		// an object of your newly created type.
+		log.Error("Server stopped: %s", http.ListenAndServeTLS(addr, certFilename, keyFilename, p))
+	}
 }


### PR DESCRIPTION
## Overview
This PR introduces a new command line flag --skip-tls, which allows users to opt out of using TLS for serving HTTP requests. When this flag is set to true, the application will use http.ListenAndServe() instead of http.ListenAndServeTLS(), enabling the server to handle HTTP requests without TLS encryption.

This change is fully backwards compatible as it introduces a new flag with a default behavior that maintains the existing functionality (using TLS).

## Motivation
The motivation behind this change is to provide flexibility for scenarios where TLS encryption may not be necessary, such as in a secure, internal network or for local development and testing purposes. This helps in reducing the complexity and overhead associated with managing TLS certificates, especially in environments where security requirements are relaxed.

## Documentation
Updated the relevant sections of the documentation to include information about the new --skip-tls flag and its usage.