### PR TITLE
initialize config using NewConfig

### DIFF
--- a/cmd/tesla-http-proxy/main.go
+++ b/cmd/tesla-http-proxy/main.go
@@ -44,8 +44,8 @@ func main() {
 		host         string
 		port         int
 	)
-	config := cli.Config{Flags: cli.FlagPrivateKey}
-	var err error
+
+	config, err := cli.NewConfig(cli.FlagPrivateKey)
 	defer func() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", err)


### PR DESCRIPTION
Standardized configuration initialization to match other commands, addressing an issue where default config values were not being loaded. This fix resolves errors related to missing keyring names.