### PR TITLE
README: Force use of named curves in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ purposes, you can create a self-signed localhost server certificate using
 OpenSSL:
 
 ```
-openssl req -x509 -nodes -newkey ec -pkeyopt ec_paramgen_curve:secp521r1 \
+openssl req -x509 -nodes -newkey ec \
+    -pkeyopt ec_paramgen_curve:secp521r1 \
+    -pkeyopt ec_param_enc:named_curve  \
     -subj '/CN=localhost' \
     -keyout key.pem -out cert.pem -sha256 -days 3650 \
     -addext "extendedKeyUsage = serverAuth" \


### PR DESCRIPTION
MacOS uses LibreSSL for the OpenSSL command, and LibreSSL defaults to using explicit curve parameters rather than named curves when encoding private keys with `openssl req ...`. But the Golang x509 library does not support explicit curve parameters, causing `tesla-http-proxy` to fail with "x509: invalid ECDSA parameters".

This commit fixes the problem by adding an option to the openssl command in the README that forces LibreSSL to use named curves.

# Description

Please include a summary of the changes and the related issue.

Fixes #83 

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
