### PR TITLE
Spelling fixes

### DIFF
--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -322,7 +322,7 @@ func (d *Dispatcher) Send(ctx context.Context, message *universal.RoutableMessag
 
 	addr := make([]byte, addressLength)
 	// Message UUIDs are only used for debugging message logs and are not
-	// copied into the recieverKey used to match responses to requests.
+	// copied into the receiverKey used to match responses to requests.
 	uuid := make([]byte, uuidLength)
 	if _, err := rand.Read(uuid); err != nil {
 		return nil, err

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -770,7 +770,7 @@ func TestDoNotBlockOnResponder(t *testing.T) {
 	select {
 	case <-rsp2.Recv():
 	case <-ctx.Done():
-		t.Fatalf("Didn't recieve message for second command: %s", err)
+		t.Fatalf("Didn't receive message for second command: %s", err)
 	}
 
 	// Check that responderBufferSize messages (and no more!) arrived at the rsp1.
@@ -778,13 +778,13 @@ func TestDoNotBlockOnResponder(t *testing.T) {
 		select {
 		case <-rsp1.Recv():
 		case <-ctx.Done():
-			t.Fatalf("Didn't recieve message for second command: %s", err)
+			t.Fatalf("Didn't receive message for second command: %s", err)
 		}
 	}
 
 	select {
 	case <-rsp1.Recv():
-		t.Fatalf("Recieved more messages than expected")
+		t.Fatalf("Received more messages than expected")
 	case <-ctx.Done():
 	}
 }

--- a/pkg/connector/ble/ble.go
+++ b/pkg/connector/ble/ble.go
@@ -112,10 +112,6 @@ func (c *Connection) Send(ctx context.Context, buffer []byte) error {
 	return nil
 }
 
-func (c *Connection) Recieve() <-chan []byte {
-	return c.inbox
-}
-
 func (c *Connection) VIN() string {
 	return c.vin
 }


### PR DESCRIPTION
# Description

"Recieve" -> "Receive". D'oh!

The pkg/connector/ble/ble.go method had both Receive and Recieve methods. Deleting the latter is an API-breaking change, but such changes should be expected in v0.x.x according to Go semantic versioning standards.
Fixes #60 

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
