### PR TITLE
tesla-control: Fix wakeup over BLE

### DIFF
--- a/cmd/tesla-control/commands.go
+++ b/cmd/tesla-control/commands.go
@@ -42,7 +42,7 @@ func configureFlags(c *cli.Config, commandName string, forceBLE bool) error {
 		return ErrUnknownCommand
 	}
 	c.Flags = cli.FlagBLE
-	if info.requiresAuth {
+	if (forceBLE && commandName == "wake") || info.requiresAuth {
 		c.Flags |= cli.FlagPrivateKey | cli.FlagVIN
 	}
 	if !info.requiresFleetAPI {


### PR DESCRIPTION
The wake command requires authentication over BLE, but not over Fleet API. This commit adds special logic to tesla-control to handle this.

# Description

Please include a summary of the changes and the related issue.

Fixes #51 

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
