### PR TITLE
Fix race condition in ErrProtocolNotSupported

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -263,7 +263,7 @@ func (p *Proxy) handleVehicleCommand(acct *account.Account, w http.ResponseWrite
 	}
 	defer car.Disconnect()
 
-	if err := car.StartSession(ctx, nil); err == protocol.ErrProtocolNotSupported {
+	if err := car.StartSession(ctx, nil); errors.Is(err, protocol.ErrProtocolNotSupported) {
 		p.markUnsupportedVIN(vin)
 		p.forwardRequest(acct.Host, w, req)
 		return err


### PR DESCRIPTION
Fixed a race condition that caused the library (and http proxy) to not recognize ErrProtocolNotSupported, which indicates the vehicle does not support the newer protocol.

The race condition was caused by code that attempted to handshake with multiple vehicle subsystems (domains) in parallel. If one subsystem returned ErrProtocolNotSupported, the pending requests to other subsystems were canceled. In some cases, the context cancellation error would be propagated to the down the stack instead of ErrProtocolNotSupported.

With this fix, the library prioritizes non-context cancellation errors.

# Description

Please include a summary of the changes and the related issue.

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
