### PR TITLE
Fix regression in session info

### DIFF
--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -116,7 +116,7 @@ func (d *Dispatcher) StartSessions(ctx context.Context, domains []universal.Doma
 		err = <-results
 		// The aggregateContext is canceled if one of the handshakes fails. We don't want to return
 		// the Canceled error if ErrProtocolNotSupported is present.
-		if !errors.Is(err, context.Canceled) {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			return err
 		}
 	}

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 var errOutboxFull = errors.New("dispatcher: outbox full")
+var errDropMessage = errors.New("dispatcher: simulated dropped message")
 var errTimeout = errors.New("dispatcher: simulated timeout")
 var testPayload = []byte("ack")
 var quiescentDelay = 250 * time.Millisecond
@@ -246,7 +247,11 @@ func (d *dummyConnector) Send(ctx context.Context, buffer []byte) error {
 		err := d.errorQueue[0]
 		d.errorQueue = d.errorQueue[1:]
 		d.lock.Unlock()
-		return err
+		if err == errDropMessage {
+			return nil
+		} else if err != nil {
+			return err
+		}
 	}
 	if err := proto.Unmarshal(buffer, &message); err != nil {
 		return err
@@ -643,6 +648,36 @@ func TestConnect(t *testing.T) {
 
 	if _, err := dispatcher.Send(ctx, testCommand(), connector.AuthMethodHMAC); err != nil {
 		t.Errorf("Unexpected error: %s", err)
+	}
+}
+
+func TestWaitForAllSessions(t *testing.T) {
+	conn := newDummyConnector(t)
+	defer conn.Close()
+
+	// Configure the Connector to only respond to the first of two handshakes
+	conn.EnqueueSendError(nil)
+	conn.EnqueueSendError(errDropMessage)
+
+	key, err := authentication.NewECDHPrivateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("Couldn't create private key: %s", err)
+	}
+
+	dispatcher, err := New(conn, key)
+	if err != nil {
+		t.Fatalf("Couldn't initialize dispatcher: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), quiescentDelay)
+	defer cancel()
+
+	if err := dispatcher.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := dispatcher.StartSessions(ctx, nil); err != context.DeadlineExceeded {
+		t.Fatalf("Unexpected error: %s", err)
 	}
 }
 


### PR DESCRIPTION
# Description

Commit beb8735ec5fa86de1ca60cfee52f1fe784521cfc introduced a regression that prevents clients from establishing session info on connections that are not cached. It caused a handshake to one domain to be cancelled when a handshake to another domain succeeded.

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
