### PR TITLE
Fix usage of `tesla-keygen migrate`

### DIFF
--- a/cmd/tesla-keygen/main.go
+++ b/cmd/tesla-keygen/main.go
@@ -95,7 +95,7 @@ func main() {
 	switch flag.Arg(0) {
 	case "migrate":
 		if config.KeyFilename == "" || config.KeyringKeyName == "" {
-			writeErr("Must provide path of existing key (-key-file-name) and name of new key (-key-name)")
+			writeErr("Must provide path of existing key (-key-file) and name of new key (-key-name)")
 			return
 		}
 


### PR DESCRIPTION
# Description

The parameter `-key-file-name` does not exist, and should be `-key-file`. Only a minor change to the console output.

No further references to `key-file-name` exist in the repository.

Fixes #163

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
