### PR TITLE
Update "Authorizing commands" section's HMAC Signature type SIGNATURE_TYPE_HMAC_PERSONALIZED

### DIFF
--- a/pkg/protocol/protocol.md
+++ b/pkg/protocol/protocol.md
@@ -528,7 +528,7 @@ The client serializes the following metadata values into a string `M`:
 
 | Value | Tag | Description |
 | ----- | --- | ----------- |
-| Signature type | `Signatures.TAG_SIGNATURE_TYPE` | Either `Signatures.SIGNATURE_TYPE_HMAC` or `Signatures.SIGNATURE_TYPE_AES_GCM_PERSONALIZED`. See below. |
+| Signature type | `Signatures.TAG_SIGNATURE_TYPE` | Either `Signatures.SIGNATURE_TYPE_HMAC_PERSONALIZED` or `Signatures.SIGNATURE_TYPE_AES_GCM_PERSONALIZED`. See below. |
 | Domain         | `Signatures.TAG_DOMAIN`         | Typically `UniversalMesasge.DOMAIN_VEHICLE_SECURITY` or `UniversalMessage.DOMAIN_INFOTAINMENT` |
 | VIN            | `Signatures.TAG_PERSONALIZATION`| 17-character vehicle identification number |
 | Epoch          | `Signatures.TAG_EPOCH`          | Copied from `session_info.epoch`           |


### PR DESCRIPTION
# Description

Updates the protocol documentation to reference the correct Signature Type for HMAC for Command Authorization

If `SIGNATURE_TYPE_HMAC` is used, an `MESSAGEFAULT_ERROR_INVALID_SIGNATURE` is received.

Swapping for `SIGNATURE_TYPE_HMAC_PERSONALIZED` with no other changes causes the commands to be signed correctly and accepted.

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [ ] My code follows the style of this project.
- [ ] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
