### PR TITLE
tesla-control: fix climate-set-temp command wrong conversion equation

### DIFF
--- a/cmd/tesla-control/commands.go
+++ b/cmd/tesla-control/commands.go
@@ -216,7 +216,7 @@ var commands = map[string]*Command{
 				return fmt.Errorf("failed to parse temperature: format as 22C or 72F")
 			}
 			if unit == "F" || unit == "f" {
-				degrees = (5.0 * degrees / 9.0) + 32.0
+				degrees = (degrees - 32.0) * 5.0 / 9.0
 			} else if unit != "C" && unit != "c" {
 				return fmt.Errorf("temperature units must be C or F")
 			}


### PR DESCRIPTION
# Description

fix climate-set-temp command wrong conversion equation

- Previously, sending a climate-set-temp command in "f or F" units set the cabin temp to HIGH. 
- Only "c or C" units were accepted Now command sets cabin to appropriate temperature in both units.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
