### PR TITLE
Fast fail 429

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,15 @@ in lieu of command-line flags when using the above applications:
  * `TESLA_VIN` specifies a vehicle identification number. You can find your VIN
    under Controls > Software in your vehicle's UI. (Despite the name, VINs
    contain both letters and numbers).
+ * `TESLA_CACHE_FILE` specifies a file that caches session information. The
+   cache allows programs to skip sending handshake messages to a vehicle.
 
 For example:
 
 ```bash
 export TESLA_KEY_NAME=$(whoami)
 export TESLA_TOKEN_NAME=$(whoami)
+export TESLA_CACHE_FILE=~/.tesla-cache.json
 ```
 
 At this point, you're ready to go use the [the command-line

--- a/pkg/connector/inet/inet.go
+++ b/pkg/connector/inet/inet.go
@@ -77,8 +77,7 @@ func (e *HttpError) Temporary() bool {
 	return e.Code == http.StatusServiceUnavailable ||
 		e.Code == http.StatusGatewayTimeout ||
 		e.Code == http.StatusRequestTimeout ||
-		e.Code == http.StatusMisdirectedRequest ||
-		e.Code == http.StatusTooManyRequests
+		e.Code == http.StatusMisdirectedRequest
 }
 
 func SendFleetAPICommand(ctx context.Context, client *http.Client, userAgent, authHeader string, url string, command interface{}) ([]byte, error) {


### PR DESCRIPTION
# Description

Fast fail on 429 errors to give clients better control over retry policies.

Document TESLA_CACHE_FILE environment variable, which may help clients avoid 429s to begin with.

Fixes #238 

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
