### PR TITLE
device: return nil device on error

### DIFF
--- a/pkg/connector/ble/device_darwin.go
+++ b/pkg/connector/ble/device_darwin.go
@@ -6,5 +6,9 @@ import (
 )
 
 func newDevice() (ble.Device, error) {
-	return darwin.NewDevice()
+	device, err := darwin.NewDevice()
+	if err != nil {
+		return nil, err
+	}
+	return device, nil
 }

--- a/pkg/connector/ble/device_linux.go
+++ b/pkg/connector/ble/device_linux.go
@@ -6,5 +6,9 @@ import (
 )
 
 func newDevice() (ble.Device, error) {
-	return linux.NewDevice()
+	device, err := linux.NewDevice()
+	if err != nil {
+		return nil, err
+	}
+	return device, nil
 }


### PR DESCRIPTION
# Description

In the file `pkg/connector/ble/ble.go` there is a check for `device != nil`, however this can be false even though the previous call failed to init the ble device. 

The reason is that the `Device` is an interface and for interface to be `nil` it needs to have both value and a type nil, see
https://go.dev/doc/faq#nil_error

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
