### PR TITLE
Improve BLE reliability

### DIFF
--- a/cmd/tesla-control/commands.go
+++ b/cmd/tesla-control/commands.go
@@ -655,7 +655,7 @@ var commands = map[string]*Command{
 	},
 	"session-info": &Command{
 		help:             "Retrieve session info for PUBLIC_KEY from DOMAIN",
-		requiresAuth:     true,
+		requiresAuth:     false,
 		requiresFleetAPI: false,
 		args: []Argument{
 			Argument{name: "PUBLIC_KEY", help: "file containing public key (or corresponding private key)"},

--- a/pkg/connector/ble/device_linux.go
+++ b/pkg/connector/ble/device_linux.go
@@ -3,10 +3,24 @@ package ble
 import (
 	"github.com/go-ble/ble"
 	"github.com/go-ble/ble/linux"
+	"github.com/go-ble/ble/linux/hci/cmd"
+	"time"
 )
 
+const bleTimeout = 20 * time.Second
+
+// TODO: Depending on the model and state, BLE advertisements come every 20ms or every 150ms.
+
+var scanParams = cmd.LESetScanParameters{
+	LEScanType:           1,    // Active scanning
+	LEScanInterval:       0x10, // 10ms
+	LEScanWindow:         0x10, // 10ms
+	OwnAddressType:       0,    // Static
+	ScanningFilterPolicy: 2,    // Basic filtered
+}
+
 func newDevice() (ble.Device, error) {
-	device, err := linux.NewDevice()
+	device, err := linux.NewDevice(ble.OptListenerTimeout(bleTimeout), ble.OptDialerTimeout(bleTimeout), ble.OptScanParams(scanParams))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Improve BLE connection reliability:

 - Increase timeouts for BLE dialer and listener
 - Retry initial connection on non-fatal errors until context expires
 - Tweak scanning interval to reflect BLE advertisement parameters

Future improvements (deferred to get the existing improvements merged sooner):

 - Retry connection using client MAC address instead of scanning
 - Optimize scanning interval
 - Adjust timeouts using caller context

Fixes #253 

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
