### PR TITLE
upgrade to golang-jwt/jwt v5

### DIFF
--- a/cmd/tesla-jws/main.go
+++ b/cmd/tesla-jws/main.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/teslamotors/vehicle-command/internal/authentication"
 	"github.com/teslamotors/vehicle-command/pkg/cli"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/99designs/keyring v1.2.2
 	github.com/cronokirby/saferith v0.33.0
 	github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	golang.org/x/term v0.5.0
 	google.golang.org/protobuf v1.34.2

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633 h1:ZrzoZQz1CF33SPHLkjRp
 github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633/go.mod h1:fFJl/jD/uyILGBeD5iQ8tYHrPlJafyqCJzAyTHNJ1Uk=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=

--- a/internal/authentication/jwt_test.go
+++ b/internal/authentication/jwt_test.go
@@ -3,7 +3,7 @@ package authentication
 import (
 	"testing"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const testVIN = "0123456789abcdefX"

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/teslamotors/vehicle-command/internal/authentication"
 	"github.com/teslamotors/vehicle-command/internal/log"


### PR DESCRIPTION
# Description

Upgrade `github.com/golang-jwt/jwt` to `github.com/golang-jwt/jwt/v5`.

[Migration guide used](https://github.com/golang-jwt/jwt/blob/v5.2.1/MIGRATION_GUIDE.md).

To test, I configured a vehicle for fleet-telemetry using the http proxy.

Fixes #294 

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
