### PR TITLE
Add function to enable DebugLog from for external use

### DIFF
--- a/pkg/connector/ble/ble.go
+++ b/pkg/connector/ble/ble.go
@@ -36,6 +36,10 @@ var (
 	mu     sync.Mutex
 )
 
+func SetDebugLog() {
+	log.SetLevel(log.LevelDebug)
+}
+
 type Connection struct {
 	vin         string
 	inbox       chan []byte


### PR DESCRIPTION
# Description

Just a view lines to create the possibility to enable debug logs when using this library in another go app. The log package is otherwise not accessible because it is internal.

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
