### PR TITLE
retry for other region

### DIFF
--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -67,6 +67,7 @@ type Account struct {
 	UserAgent  string
 	authHeader string
 	Host       string
+	Subject    string
 	client     http.Client
 }
 
@@ -74,6 +75,7 @@ type Account struct {
 type oauthPayload struct {
 	Audiences []string `json:"aud"`
 	OUCode    string   `json:"ou_code"`
+	Subject   string   `json:"sub"`
 }
 
 var domainRegEx = regexp.MustCompile(`^[A-Za-z0-9-.]+$`) // We're mostly interested in stopping paths; the http package handles the rest.
@@ -136,6 +138,7 @@ func New(oauthToken, userAgent string) (*Account, error) {
 		UserAgent:  buildUserAgent(userAgent),
 		authHeader: "Bearer " + strings.TrimSpace(oauthToken),
 		Host:       domain,
+		Subject:    payload.Subject,
 	}, nil
 }
 

--- a/pkg/account/account_test.go
+++ b/pkg/account/account_test.go
@@ -67,7 +67,8 @@ func TestDomainExtraction(t *testing.T) {
 			"https://fleet-api.prd.na.vn.cloud.tesla.com",
 			"https://fleet-api.prd.eu.vn.cloud.tesla.com",
 		},
-		OUCode: "EU",
+		OUCode:  "EU",
+		Subject: "SUBJECT",
 	}
 
 	acct, err := New(makeTestJWT(payload), "")
@@ -75,7 +76,7 @@ func TestDomainExtraction(t *testing.T) {
 		t.Fatalf("Returned error on valid JWT: %s", err)
 	}
 	expectedHost := "fleet-api.prd.eu.vn.cloud.tesla.com"
-	if acct == nil || acct.Host != expectedHost {
+	if acct == nil || acct.Host != expectedHost || acct.Subject != "SUBJECT" {
 		t.Errorf("acct = %+v, expected Host = %s", acct, expectedHost)
 	}
 }

--- a/pkg/connector/inet/inet.go
+++ b/pkg/connector/inet/inet.go
@@ -21,7 +21,7 @@ import (
 // MaxLatency is the default maximum latency permitted when updating the vehicle clock estimate.
 var MaxLatency = 10 * time.Second
 
-func readWithContext(ctx context.Context, r io.Reader, p []byte) ([]byte, error) {
+func ReadWithContext(ctx context.Context, r io.Reader, p []byte) ([]byte, error) {
 	bytesRead := 0
 	for {
 		if ctx.Err() != nil {
@@ -108,7 +108,7 @@ func SendFleetAPICommand(ctx context.Context, client *http.Client, userAgent, au
 	defer result.Body.Close()
 
 	body = make([]byte, connector.MaxResponseLength+1)
-	body, err = readWithContext(ctx, result.Body, body)
+	body, err = ReadWithContext(ctx, result.Body, body)
 	if err != nil {
 		return nil, &protocol.CommandError{Err: err, PossibleSuccess: true, PossibleTemporary: false}
 	}


### PR DESCRIPTION
# Description

currently vehicle command will retry commands if tesla host return 421. We want to share the same behavior for other proxied request as well.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [ ] My code follows the style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
