### PR TITLE
- Fixed build on Windows

### DIFF
--- a/pkg/connector/ble/device_windows.go
+++ b/pkg/connector/ble/device_windows.go
@@ -1,0 +1,10 @@
+package ble
+
+import (
+	"errors"
+	"github.com/go-ble/ble"
+)
+
+func newDevice() (ble.Device, error) {
+	return nil, errors.New("Not supported on Windows")
+}

--- a/pkg/connector/ble/device_windows.go
+++ b/pkg/connector/ble/device_windows.go
@@ -6,5 +6,5 @@ import (
 )
 
 func newDevice() (ble.Device, error) {
-	return nil, errors.New("Not supported on Windows")
+	return nil, errors.New("not supported on Windows")
 }


### PR DESCRIPTION
# Description

Fixes show-stopper build on Windows:

```raw
> go build ./...
# github.com/teslamotors/vehicle-command/pkg/connector/ble
..\..\pkg\connector\ble\ble.go:161:17: undefined: newDevice
```

Even if not supported for BLE, building on Windows is still possible for other targets like the `tesla-http-proxy`. With the proposed basic change the build is unblocked.

Invoking commands that involves BLE will be correctly report the runtime error:

```raw
> tesla-control -ble add-key-request public_key.pem owner cloud_key
Error: failed to find a BLE device: Not supported on Windows
```

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Bug fix (non-breaking change which fixes an build issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [X] No need to update the documentation.
- [X] No need for unit tests.
