### PR TITLE
Use non root image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN mkdir build
 RUN go build -o ./build ./...
 
-FROM gcr.io/distroless/base-debian12 AS runtime
+FROM gcr.io/distroless/base-debian12:nonroot AS runtime
 
 COPY --from=build /app/build /usr/local/bin
 


### PR DESCRIPTION
# Description

Similar to https://github.com/teslamotors/fleet-telemetry/pull/224, there should be no need to run the docker image as root


## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
