### PR TITLE
tesla-control: enable/disable valet mode

### DIFF
--- a/cmd/tesla-control/commands.go
+++ b/cmd/tesla-control/commands.go
@@ -243,6 +243,25 @@ func (c *Command) Usage(name string) {
 }
 
 var commands = map[string]*Command{
+	"valet-mode-on": &Command{
+		help:             "Enable valet mode",
+		requiresAuth:     true,
+		requiresFleetAPI: false,
+		args: []Argument{
+			Argument{name: "PIN", help: "Valet mode PIN"},
+		},
+		handler: func(ctx context.Context, acct *account.Account, car *vehicle.Vehicle, args map[string]string) error {
+			return car.EnableValetMode(ctx, args["PIN"])
+		},
+	},
+	"valet-mode-off": &Command{
+		help:             "Disable valet mode",
+		requiresAuth:     true,
+		requiresFleetAPI: false,
+		handler: func(ctx context.Context, acct *account.Account, car *vehicle.Vehicle, args map[string]string) error {
+			return car.DisableValetMode(ctx)
+		},
+	},
 	"unlock": &Command{
 		help:             "Unlock vehicle",
 		requiresAuth:     true,

--- a/pkg/vehicle/security_test.go
+++ b/pkg/vehicle/security_test.go
@@ -1,0 +1,30 @@
+package vehicle
+
+import (
+	"testing"
+)
+
+func TestValidPIN(t *testing.T) {
+	validPINs := []string{
+		"0000",
+		"0123",
+		"4569",
+	}
+	invalidPINs := []string{
+		"",
+		"123a",
+		"12345",
+		"1",
+		"four",
+	}
+	for _, p := range validPINs {
+		if !IsValidPIN(p) {
+			t.Errorf("%s is a valid PIN", p)
+		}
+	}
+	for _, p := range invalidPINs {
+		if IsValidPIN(p) {
+			t.Errorf("%s is not a valid PIN", p)
+		}
+	}
+}


### PR DESCRIPTION
Adds valet mode commands to the tesla-control CLI tool. These commands were already supported in the library and HTTP proxy.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
