### PR TITLE
Refactor BLE connecting to allow scanning for vehicle presence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23
 require (
 	github.com/99designs/keyring v1.2.2
 	github.com/cronokirby/saferith v0.33.0
-	github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633
+	github.com/go-ble/ble v0.0.0-20240122180141-8c5522f54333
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	golang.org/x/term v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633 h1:ZrzoZQz1CF33SPHLkjRpnVuZwr9cO1lTEc4Js7SgBos=
-github.com/go-ble/ble v0.0.0-20220207185428-60d1eecf2633/go.mod h1:fFJl/jD/uyILGBeD5iQ8tYHrPlJafyqCJzAyTHNJ1Uk=
+github.com/go-ble/ble v0.0.0-20240122180141-8c5522f54333 h1:bQK6D51cNzMSTyAf0HtM30V2IbljHTDam7jru9JNlJA=
+github.com/go-ble/ble v0.0.0-20240122180141-8c5522f54333/go.mod h1:fFJl/jD/uyILGBeD5iQ8tYHrPlJafyqCJzAyTHNJ1Uk=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=

--- a/pkg/connector/ble/ble.go
+++ b/pkg/connector/ble/ble.go
@@ -169,13 +169,6 @@ func ScanVehicleBeacon(ctx context.Context, vin string) (Advertisement, error) {
 func scanVehicleBeacon(ctx context.Context, localName string) (Advertisement, error) {
 	var err error
 	ctx2, cancel := context.WithCancel(ctx)
-	go func() {
-		select {
-		case <-ctx.Done():
-			cancel()
-		case <-ctx2.Done():
-		}
-	}()
 
 	ch := make(chan Advertisement)
 	fn := func(a Advertisement) {

--- a/pkg/connector/ble/ble.go
+++ b/pkg/connector/ble/ble.go
@@ -172,8 +172,7 @@ func scanVehicleBeacon(ctx context.Context, localName string) (Advertisement, er
 
 	ch := make(chan Advertisement)
 	fn := func(a Advertisement) {
-		ln := a.LocalName()
-		if ln != localName {
+		if a.LocalName() != localName {
 			return
 		}
 		cancel()

--- a/pkg/connector/ble/ble.go
+++ b/pkg/connector/ble/ble.go
@@ -125,10 +125,89 @@ func (c *Connection) VIN() string {
 	return c.vin
 }
 
+func VehicleLocalName(vin string) string {
+	vinBytes := []byte(vin)
+	digest := sha1.Sum(vinBytes)
+	return fmt.Sprintf("S%02xC", digest[:8])
+}
+
+func initDevice() error {
+	var err error
+	// We don't want concurrent calls to NewConnection that would defeat
+	// the point of reusing the existing BLE device. Note that this is not
+	// an issue on MacOS, but multiple calls to newDevice() on Linux leads to failures.
+	if device != nil {
+		log.Debug("Reusing existing BLE device")
+	} else {
+		log.Debug("Creating new BLE device")
+		device, err = newDevice()
+		if err != nil {
+			return fmt.Errorf("failed to find a BLE device: %s", err)
+		}
+		ble.SetDefaultDevice(device)
+	}
+	return nil
+}
+
+type Advertisement = ble.Advertisement
+
+func ScanVehicleBeacon(ctx context.Context, vin string) (Advertisement, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if err := initDevice(); err != nil {
+		return nil, err
+	}
+
+	a, err := scanVehicleBeacon(ctx, VehicleLocalName(vin))
+	if err != nil {
+		return nil, fmt.Errorf("ble: failed to scan for %s: %s", vin, err)
+	}
+	return a, nil
+}
+
+func scanVehicleBeacon(ctx context.Context, localName string) (Advertisement, error) {
+	var err error
+	ctx2, cancel := context.WithCancel(ctx)
+	go func() {
+		select {
+		case <-ctx.Done():
+			cancel()
+		case <-ctx2.Done():
+		}
+	}()
+
+	ch := make(chan Advertisement)
+	fn := func(a Advertisement) {
+		ln := a.LocalName()
+		if ln != localName {
+			return
+		}
+		cancel()
+		ch <- a
+	}
+	err = device.Scan(ctx2, false, fn)
+
+	select {
+	case a, ok := <-ch:
+		if !ok {
+			// This should never happen, but just in case
+			return nil, fmt.Errorf("scan channel closed")
+		}
+		return a, nil
+	default:
+		return nil, err
+	}
+}
+
 func NewConnection(ctx context.Context, vin string) (*Connection, error) {
+	return NewConnectionToBleTarget(ctx, vin, nil)
+}
+
+func NewConnectionToBleTarget(ctx context.Context, vin string, target Advertisement) (*Connection, error) {
 	var lastError error
 	for {
-		conn, err := tryToConnect(ctx, vin)
+		conn, err := tryToConnect(ctx, vin, target)
 		if err == nil {
 			return conn, nil
 		}
@@ -146,50 +225,40 @@ func NewConnection(ctx context.Context, vin string) (*Connection, error) {
 	}
 }
 
-func tryToConnect(ctx context.Context, vin string) (*Connection, error) {
+func tryToConnect(ctx context.Context, vin string, target Advertisement) (*Connection, error) {
 	var err error
-	// We don't want concurrent calls to NewConnection that would defeat
-	// the point of reusing the existing BLE device. Note that this is not
-	// an issue on MacOS, but multiple calls to newDevice() on Linux leads to failures.
 	mu.Lock()
 	defer mu.Unlock()
 
-	if device != nil {
-		log.Debug("Reusing existing BLE device")
-	} else {
-		log.Debug("Creating new BLE device")
-		device, err = newDevice()
+	if err = initDevice(); err != nil {
+		return nil, err
+	}
+
+	localName := VehicleLocalName(vin)
+
+	if target == nil {
+		target, err = scanVehicleBeacon(ctx, localName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find a BLE device: %s", err)
+			return nil, fmt.Errorf("ble: failed to scan for %s: %s", vin, err)
 		}
-		ble.SetDefaultDevice(device)
 	}
 
-	vinBytes := []byte(vin)
-	digest := sha1.Sum(vinBytes)
-
-	localName := fmt.Sprintf("S%02xC", digest[:8])
-	log.Debug("Searching for BLE beacon %s...", localName)
-	canConnect := false
-	filter := func(adv ble.Advertisement) bool {
-		ln := adv.LocalName()
-		if ln != localName {
-			return false
-		}
-		canConnect = adv.Connectable()
-		return true
+	if target.LocalName() != localName {
+		return nil, fmt.Errorf("ble: beacon with unexpected local name: '%s'", target.LocalName())
 	}
 
-	client, err := ble.Connect(ctx, filter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find BLE beacon for %s (%s): %s", vin, localName, err)
-	}
-
-	if !canConnect {
+	if !target.Connectable() {
 		return nil, ErrMaxConnectionsExceeded
 	}
 
-	log.Debug("Connecting to BLE beacon %s...", client.Addr())
+	log.Debug("Dialing to %s (%s)...", target.Addr(), localName)
+
+	client, err := ble.Dial(ctx, target.Addr())
+	if err != nil {
+		return nil, fmt.Errorf("ble: failed to dial for %s (%s): %s", vin, localName, err)
+	}
+
+	log.Debug("Discovering services %s...", client.Addr())
 	services, err := client.DiscoverServices([]ble.UUID{vehicleServiceUUID})
 	if err != nil {
 		return nil, fmt.Errorf("ble: failed to enumerate device services: %s", err)


### PR DESCRIPTION
# Description

This PR splits the `ble.tryToConnect` method in to two parts, by factoring out its first step in which we scan for a suitable tesla BLE advertisement (beacon). This is achieved by putting the code in a new `ble.scanVehicleBeacon` method along with other smaller refactorings. This allows us to expose the new method with `ble.ScanVehicleBeacon`.

The end user can then use a different (shorter) timeout to check for the presence of the vehicle before deciding if it wants to try to connect, since if a beacon got detected it would make sense to use a longer timeout to connect, or even do multiple retries, and if it wasn't detected allow for faster error handling.

Example
```go
// Old way
conn, err := ble.NewConnection(ctx, vin)

// New way

// Either try to connect immediatly
conn, err := ble.NewConnection(ctx, vin)
// Or
scanCtx, scanCancel = context.withTimeout(ctx, 1*time.Second)
defer scanCancel()
beacon, err := ble.ScanVehicleBeacon(scanCtx, vin)
if err != nil {
  handleErr(err)
}
conn, err := ble.NewConnectionToBleTarget(ctx, vin, beacon)
```


## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
