### PR TITLE
Fix FromVCSECMessage.nominalError documentation

### DIFF
--- a/pkg/protocol/protocol.md
+++ b/pkg/protocol/protocol.md
@@ -825,4 +825,4 @@ key), a message is terminal if
 client should drop empty messages.
 
 For non-whitelist operations, an empty message indicates success and
-`FromVCSECMessage.commandStatus.nominalError` indicates an error.
+`FromVCSECMessage.nominalError` indicates an error.


### PR DESCRIPTION
# Description

The referenced field is incorrect according to the proto
https://github.com/teslamotors/vehicle-command/blob/main/pkg/protocol/protobuf/vcsec.proto#L288

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
