### PR TITLE
Allow selecting BT adapter via BD address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cscope.*
 cmd/tesla-control/tesla-control
 cmd/tesla-auth-token/tesla-auth-token
 cmd/tesla-key-setup/tesla-key-setup
+cmd/test-ble/test-ble
 examples/unlock/unlock
 examples/ble/ble
 *.DS_Store

--- a/cmd/test-ble/main.go
+++ b/cmd/test-ble/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"strings"
+
+	goble "github.com/go-ble/ble"
+	"github.com/teslamotors/vehicle-command/internal/log"
+	"github.com/teslamotors/vehicle-command/pkg/connector/ble"
+)
+
+var (
+	bdAddr = flag.String("bdAddr", "", "Bluetooth device address")
+)
+
+func main() {
+	flag.Parse()
+	log.SetLevel(log.LevelDebug)
+
+	var err error
+	if bdAddr != nil {
+		log.Info("Target BLE device address: %s", *bdAddr)
+		err = ble.InitDevice(goble.NewAddr(*bdAddr))
+	} else {
+		log.Info("Using first available BLE device")
+		err = ble.InitDevice(nil)
+	}
+
+	if err != nil {
+		if strings.Contains(err.Error(), "failed to find a BLE device") {
+			log.Error("No BLE device found")
+		} else {
+			log.Error("Failed to initialize BLE device: %v", err)
+		}
+		return
+	}
+
+	log.Info("BLE is working")
+}

--- a/pkg/connector/ble/device_darwin.go
+++ b/pkg/connector/ble/device_darwin.go
@@ -3,9 +3,13 @@ package ble
 import (
 	"github.com/go-ble/ble"
 	"github.com/go-ble/ble/darwin"
+	"github.com/teslamotors/vehicle-command/internal/log"
 )
 
-func newDevice(ble.Addr) (ble.Device, error) {
+func newDevice(bdAddr ble.Addr) (ble.Device, error) {
+	if bdAddr != nil || bdAddr.String() != "" {
+		log.Warning("Setting the Bluetooth device address is not supported on Darwin")
+	}
 	device, err := darwin.NewDevice()
 	if err != nil {
 		return nil, err

--- a/pkg/connector/ble/device_darwin.go
+++ b/pkg/connector/ble/device_darwin.go
@@ -5,7 +5,7 @@ import (
 	"github.com/go-ble/ble/darwin"
 )
 
-func newDevice() (ble.Device, error) {
+func newDevice(ble.Addr) (ble.Device, error) {
 	device, err := darwin.NewDevice()
 	if err != nil {
 		return nil, err

--- a/pkg/connector/ble/device_linux.go
+++ b/pkg/connector/ble/device_linux.go
@@ -1,10 +1,15 @@
 package ble
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/go-ble/ble"
 	"github.com/go-ble/ble/linux"
+	"github.com/go-ble/ble/linux/hci"
 	"github.com/go-ble/ble/linux/hci/cmd"
-	"time"
+	"github.com/teslamotors/vehicle-command/internal/log"
 )
 
 const bleTimeout = 20 * time.Second
@@ -19,8 +24,55 @@ var scanParams = cmd.LESetScanParameters{
 	ScanningFilterPolicy: 2,    // Basic filtered
 }
 
-func newDevice() (ble.Device, error) {
-	device, err := linux.NewDevice(ble.OptListenerTimeout(bleTimeout), ble.OptDialerTimeout(bleTimeout), ble.OptScanParams(scanParams))
+func newDevice(bdAddr ble.Addr) (ble.Device, error) {
+	maxHciDevices := 16
+	hciX := -1
+	log.Debug("Scanning for HCI devices")
+	bdAddrStr := ""
+	if bdAddr != nil {
+		bdAddrStr = bdAddr.String()
+	}
+	var lastErr error
+	for i := 0; i < maxHciDevices; i++ {
+		devHci, err := hci.NewHCI(ble.OptDeviceID(i))
+		if err != nil {
+			return nil, fmt.Errorf("can't create HCI %d: %v", i, err)
+		}
+
+		if err = devHci.Init(); err != nil {
+			if !strings.Contains(err.Error(), "no such device") {
+				lastErr = err
+				log.Debug("Can't init HCI %d: %v", i, err)
+			}
+			continue
+		}
+		if err = devHci.Close(); err != nil {
+			return nil, fmt.Errorf("can't close HCI %d: %v", i, err)
+		}
+
+		log.Debug("Found HCI %d: %s", i, devHci.Addr())
+		if bdAddrStr == "" || devHci.Addr().String() == bdAddrStr {
+			hciX = i
+			break
+		}
+	}
+
+	if hciX == -1 && lastErr != nil {
+		return nil, lastErr
+	} else if hciX == -1 {
+		return nil, fmt.Errorf("no device with address %s", bdAddr)
+	}
+	log.Debug("Using HCI %d", hciX)
+
+	opts := []ble.Option{
+		ble.OptDeviceID(hciX),
+		ble.OptListenerTimeout(bleTimeout),
+		ble.OptDialerTimeout(bleTimeout),
+		ble.OptScanParams(scanParams),
+	}
+
+	device, err := linux.NewDeviceWithName("vehicle-command", opts...)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/ble/device_windows.go
+++ b/pkg/connector/ble/device_windows.go
@@ -2,9 +2,10 @@ package ble
 
 import (
 	"errors"
+
 	"github.com/go-ble/ble"
 )
 
-func newDevice() (ble.Device, error) {
+func newDevice(ble.Addr) (ble.Device, error) {
 	return nil, errors.New("not supported on Windows")
 }


### PR DESCRIPTION
# Description

Instead of only scanning hci devices for first available one (like #369), allow the user to define target Bluetooth device address, which uniquely identifies a hci device, making hci ordering changes not an issue. If address is not specified it will use the first available one. Also adds a small testing utility program in `cmd/test-ble` and configuration option for `vehicle-control` utility.

Right now only MAC address on linux is supported, but someone with a mac could probably implement something similar on Darwin, with UUIDs.

Example:
```
lenart@etera:~$ ./tesla-control -ble -bdAddr 43:45:c0:00:1f:ae -vin VIN body-controller-state
Error: failed to find a BLE device: can't down device: operation not permitted

Try again after granting this application CAP_NET_ADMIN:

        sudo setcap 'cap_net_admin=eip' "$(which ./tesla-control)"

lenart@etera:~$ sudo ./tesla-control -ble -bdAddr 43:45:c0:00:1f:ae -vin VIN body-controller-state
[sudo] password for lenart:
Error: failed to find a BLE device: no device with address 43:45:c0:00:1f:ae
lenart@etera:~$ sudo ./tesla-control -ble -bdAddr 43:45:c0:00:1f:ac -vin VIN body-controller-state
{
        "vehicleLockState": "VEHICLELOCKSTATE_LOCKED",
        "vehicleSleepStatus": "VEHICLE_SLEEP_STATUS_ASLEEP",
        "userPresence": "VEHICLE_USER_PRESENCE_NOT_PRESENT"
}
lenart@etera:~$ sudo ./tesla-control -ble -vin VIN body-controller-state
{
        "vehicleLockState": "VEHICLELOCKSTATE_LOCKED",
        "vehicleSleepStatus": "VEHICLE_SLEEP_STATUS_ASLEEP",
        "userPresence": "VEHICLE_USER_PRESENCE_NOT_PRESENT"
}
lenart@etera:~$ ./test-ble
2025-02-05T11:41:44+01:00 [info ] Target BLE device address:
2025-02-05T11:41:44+01:00 [debug] Creating new BLE device
2025-02-05T11:41:44+01:00 [debug] Scanning for HCI devices
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 0: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 1: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 2: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 3: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 4: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 5: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 6: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 7: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 8: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 9: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 10: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 11: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 12: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 13: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 14: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [debug] Can't init HCI 15: can't down device: operation not permitted
2025-02-05T11:41:44+01:00 [error] No BLE device found
lenart@etera:~$ sudo ./test-ble
2025-02-05T11:41:53+01:00 [info ] Target BLE device address:
2025-02-05T11:41:53+01:00 [debug] Creating new BLE device
2025-02-05T11:41:53+01:00 [debug] Scanning for HCI devices
2025-02-05T11:41:53+01:00 [debug] Found HCI 0: 43:45:c0:00:1f:ac
2025-02-05T11:41:53+01:00 [debug] Using HCI 0
2025-02-05T11:41:53+01:00 [info ] BLE is working
lenart@etera:~$ sudo ./test-ble -bdAddr 43:45:c0:00:1f:ae
2025-02-05T11:42:05+01:00 [info ] Target BLE device address: 43:45:c0:00:1f:ae
2025-02-05T11:42:05+01:00 [debug] Creating new BLE device
2025-02-05T11:42:05+01:00 [debug] Scanning for HCI devices
2025-02-05T11:42:05+01:00 [debug] Found HCI 0: 43:45:c0:00:1f:ac
2025-02-05T11:42:05+01:00 [error] No BLE device found
lenart@etera:~$ sudo ./test-ble -bdAddr 43:45:c0:00:1f:ac
2025-02-05T11:42:07+01:00 [info ] Target BLE device address: 43:45:c0:00:1f:ac
2025-02-05T11:42:07+01:00 [debug] Creating new BLE device
2025-02-05T11:42:07+01:00 [debug] Scanning for HCI devices
2025-02-05T11:42:07+01:00 [debug] Found HCI 0: 43:45:c0:00:1f:ac
2025-02-05T11:42:07+01:00 [debug] Using HCI 0
2025-02-05T11:42:07+01:00 [info ] BLE is working
```

Fixes #261

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
