### PR TITLE
Feat export funcs SignMessageForVehicle & SignMessageForFleet

### DIFF
--- a/cmd/tesla-jws/main.go
+++ b/cmd/tesla-jws/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/teslamotors/vehicle-command/internal/authentication"
 	"github.com/teslamotors/vehicle-command/pkg/cli"
+	"github.com/teslamotors/vehicle-command/pkg/sign"
 )
 
 const helpStr = `
@@ -56,7 +57,7 @@ func usage() {
 	flag.PrintDefaults()
 }
 
-func sign(config *cli.Config, fleet bool) {
+func signConfig(config *cli.Config, fleet bool) {
 	skey, err := config.PrivateKey()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load private key: %s\n", err)
@@ -78,13 +79,13 @@ func sign(config *cli.Config, fleet bool) {
 	}
 	var token string
 	if fleet {
-		token, err = authentication.SignMessageForFleet(skey, application, claims)
+		token, err = sign.SignMessageForFleet(skey, application, claims)
 	} else {
 		if config.VIN == "" {
 			fmt.Fprintln(os.Stderr, "Provide either -vin or -fleet")
 			os.Exit(1)
 		}
-		token, err = authentication.SignMessageForVehicle(skey, config.VIN, application, claims)
+		token, err = sign.SignMessageForVehicle(skey, config.VIN, application, claims)
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create JWS: %s\n", err)
@@ -164,7 +165,7 @@ func main() {
 
 	switch flag.Arg(0) {
 	case "sign":
-		sign(config, fleet)
+		signConfig(config, fleet)
 	case "verify":
 		verify()
 	default:

--- a/internal/authentication/jwt.go
+++ b/internal/authentication/jwt.go
@@ -41,26 +41,7 @@ func (s *SigningMethodSchnorrP256) Alg() string {
 	return TeslaSchnorrSHA256
 }
 
-// SignMessageForVehicle returns a JWT with the provided claims. Only the vehicle with the given VIN
-// will accept the JWT. To create a JWT that is valid for all vehicles in a fleet, use
-// [SignMessageForFleet].
-//
-// The function overwrites the audience ("aud") and issuer ("iss") JWT claims.
-func SignMessageForVehicle(privateKey ECDHPrivateKey, vin, app string, message jwt.MapClaims) (string, error) {
-	return signMessage(privateKey, message, "com.tesla.vehicle."+vin+"."+app)
-}
-
-// SignMessageForFleet returns a JWT with the provided claims. All vehicles that trust privateKey
-// will accept the JWT. To create a JWT that is valid for a single vehicle, use
-// [SignMessageForVehicle].
-//
-// The function overwrites the audience ("aud") and issuer ("iss") JWT claims.
-func SignMessageForFleet(privateKey ECDHPrivateKey, app string, message jwt.MapClaims) (string, error) {
-	// Issuers are identified by their public key
-	return signMessage(privateKey, message, "com.tesla.fleet."+app)
-}
-
-func signMessage(privateKey ECDHPrivateKey, message jwt.MapClaims, audience string) (string, error) {
+func SignMessage(privateKey ECDHPrivateKey, message jwt.MapClaims, audience string) (string, error) {
 	message["iss"] = base64.StdEncoding.EncodeToString(privateKey.PublicBytes())
 	message["aud"] = audience
 	token := jwt.New(&tss256)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -17,12 +17,12 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/teslamotors/vehicle-command/internal/authentication"
 	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/account"
 	"github.com/teslamotors/vehicle-command/pkg/cache"
 	"github.com/teslamotors/vehicle-command/pkg/connector/inet"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
+	"github.com/teslamotors/vehicle-command/pkg/sign"
 	"github.com/teslamotors/vehicle-command/pkg/vehicle"
 )
 
@@ -357,7 +357,7 @@ func (p *Proxy) handleFleetTelemetryConfig(acct *account.Account, w http.Respons
 	if _, ok := params.Config["iss"]; ok {
 		log.Warning("Configuration 'iss' field will be overwritten")
 	}
-	token, err := authentication.SignMessageForFleet(p.commandKey, "TelemetryClient", params.Config)
+	token, err := sign.SignMessageForFleet(p.commandKey, "TelemetryClient", params.Config)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, fmt.Errorf("error signing configuration: %s", err))
 		return

--- a/pkg/sign/doc.go
+++ b/pkg/sign/doc.go
@@ -1,2 +1,2 @@
-// Package sign provides functionality to sign fleet config using a ECDH private key
+// Package sign provides functionality to sign fleet configs using an ECDH private key.
 package sign

--- a/pkg/sign/doc.go
+++ b/pkg/sign/doc.go
@@ -1,0 +1,2 @@
+// Package sign provides functionality to sign fleet config using a ECDH private key
+package sign

--- a/pkg/sign/sign.go
+++ b/pkg/sign/sign.go
@@ -1,0 +1,25 @@
+package sign
+
+import (
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/teslamotors/vehicle-command/internal/authentication"
+)
+
+// SignMessageForVehicle returns a JWT with the provided claims. Only the vehicle with the given VIN
+// will accept the JWT. To create a JWT that is valid for all vehicles in a fleet, use
+// [SignMessageForFleet].
+//
+// The function overwrites the audience ("aud") and issuer ("iss") JWT claims.
+func SignMessageForVehicle(privateKey authentication.ECDHPrivateKey, vin, app string, message jwt.MapClaims) (string, error) {
+	return authentication.SignMessage(privateKey, message, "com.tesla.vehicle."+vin+"."+app)
+}
+
+// SignMessageForFleet returns a JWT with the provided claims. All vehicles that trust privateKey
+// will accept the JWT. To create a JWT that is valid for a single vehicle, use
+// [SignMessageForVehicle].
+//
+// The function overwrites the audience ("aud") and issuer ("iss") JWT claims.
+func SignMessageForFleet(privateKey authentication.ECDHPrivateKey, app string, message jwt.MapClaims) (string, error) {
+	// Issuers are identified by their public key
+	return authentication.SignMessage(privateKey, message, "com.tesla.fleet."+app)
+}


### PR DESCRIPTION
# Description
- refactor: create new public package sign
- refactor: move the func SignMessageForVehicle & SignMessageForFleet from internal/authentication to pkg/sign

Fixes #377 

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
