### PR TITLE
Fix Precondition schedule removal logic and add missing flags

### DIFF
--- a/cmd/tesla-control/commands.go
+++ b/cmd/tesla-control/commands.go
@@ -532,8 +532,9 @@ var commands = map[string]*Command{
 		},
 	},
 	"flash-lights": {
-		help:         "Flash lights",
-		requiresAuth: true,
+		help:             "Flash lights",
+		requiresAuth:     true,
+		requiresFleetAPI: false,
 		handler: func(ctx context.Context, _ *account.Account, car *vehicle.Vehicle, _ map[string]string) error {
 			return car.FlashLights(ctx)
 		},
@@ -761,7 +762,9 @@ var commands = map[string]*Command{
 		},
 	},
 	"autosecure-modelx": {
-		help: "Close falcon-wing doors and lock vehicle. Model X only.",
+		help:             "Close falcon-wing doors and lock vehicle. Model X only.",
+		requiresAuth:     true,
+		requiresFleetAPI: false,
 		handler: func(ctx context.Context, _ *account.Account, car *vehicle.Vehicle, _ map[string]string) error {
 			return car.AutoSecureVehicle(ctx)
 		},
@@ -1152,7 +1155,7 @@ var commands = map[string]*Command{
 					if err != nil {
 						return errors.New("expected numeric ID")
 					}
-					return car.RemoveChargeSchedule(ctx, id)
+					return car.RemovePreconditionSchedule(ctx, id)
 				} else {
 					return errors.New("missing schedule ID")
 				}


### PR DESCRIPTION
- Fixes issue where precondition schedules were not being removed correctly due to incorrect function call to RemoveChargeSchedule.

- Add missing requiresAuth and requiresFleetAPI flag on autosecure-modelx and flash-lights command.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
