### PR TITLE
Change example TLS key from P521 to P384

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ OpenSSL:
 ```
 mkdir config
 openssl req -x509 -nodes -newkey ec \
-    -pkeyopt ec_paramgen_curve:secp521r1 \
+    -pkeyopt ec_paramgen_curve:secp384r1 \
     -pkeyopt ec_param_enc:named_curve  \
     -subj '/CN=localhost' \
     -keyout config/tls-key.pem -out config/tls-cert.pem -sha256 -days 3650 \


### PR DESCRIPTION
Some common tools reportedly do not support NIST P521 TLS suites.

We avoid using P256 here to reduce the chance that someone will re-use the P256 command-signing key as a TLS key.

Fixes #398.

# Description

Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
