### PR TITLE
Add media control and sunroof actions to vehicle commands

### DIFF
--- a/pkg/proxy/command.go
+++ b/pkg/proxy/command.go
@@ -67,6 +67,14 @@ func ExtractCommandAction(ctx context.Context, command string, params RequestPar
 			return nil, err
 		}
 		return func(v *vehicle.Vehicle) error { return v.SetVolume(ctx, float32(volume)) }, nil
+	case "media_next_fav":
+		return func(v *vehicle.Vehicle) error { return v.MediaNextFavorite(ctx) }, nil
+	case "media_next_track":
+		return func(v *vehicle.Vehicle) error { return v.MediaNextTrack(ctx) }, nil
+	case "media_prev_fav":
+		return func(v *vehicle.Vehicle) error { return v.MediaPreviousFavorite(ctx) }, nil
+	case "media_prev_track":
+		return func(v *vehicle.Vehicle) error { return v.MediaPreviousTrack(ctx) }, nil
 	case "remote_boombox":
 		return nil, ErrCommandNotImplemented
 	case "media_toggle_playback":
@@ -480,6 +488,22 @@ func ExtractCommandAction(ctx context.Context, command string, params RequestPar
 	// end-to-end authentication.
 	case "navigation_request":
 		return nil, ErrCommandUseRESTAPI
+	case "sun_roof_control":
+		state, err := params.getString("state", true)
+		if err != nil {
+			return nil, err
+		}
+
+		switch state {
+		case "vent":
+			return func(v *vehicle.Vehicle) error { return v.VentSunRoof(ctx) }, nil
+		case "close":
+			return func(v *vehicle.Vehicle) error { return v.CloseSunRoof(ctx) }, nil
+		case "stop":
+			return func(v *vehicle.Vehicle) error { return v.StopSunRoof(ctx) }, nil
+		default:
+			return nil, errors.New("state must be 'stop', 'close', or 'vent'")
+		}
 	case "window_control":
 		// Latitude and longitude are not required for vehicles that support this protocol.
 		cmd, err := params.getString("command", true)

--- a/pkg/vehicle/actions.go
+++ b/pkg/vehicle/actions.go
@@ -94,6 +94,47 @@ func (v *Vehicle) VentWindows(ctx context.Context) error {
 		})
 }
 
+func (v *Vehicle) VentSunRoof(ctx context.Context) error {
+	return v.executeCarServerAction(ctx,
+		&carserver.Action_VehicleAction{
+			VehicleAction: &carserver.VehicleAction{
+				VehicleActionMsg: &carserver.VehicleAction_VehicleControlSunroofOpenCloseAction{
+					VehicleControlSunroofOpenCloseAction: &carserver.VehicleControlSunroofOpenCloseAction{
+						Action: &carserver.VehicleControlSunroofOpenCloseAction_Vent{
+							Vent: &carserver.Void{},
+						},
+					},
+				},
+			},
+		})
+}
+
+func (v *Vehicle) CloseSunRoof(ctx context.Context) error {
+	return v.executeCarServerAction(ctx,
+		&carserver.Action_VehicleAction{
+			VehicleAction: &carserver.VehicleAction{
+				VehicleActionMsg: &carserver.VehicleAction_VehicleControlSunroofOpenCloseAction{
+					VehicleControlSunroofOpenCloseAction: &carserver.VehicleControlSunroofOpenCloseAction{
+						Action: &carserver.VehicleControlSunroofOpenCloseAction_Close{
+							Close: &carserver.Void{},
+						},
+					},
+				},
+			},
+		})
+}
+
+func (v *Vehicle) StopSunRoof(ctx context.Context) error {
+	return v.executeCarServerAction(ctx,
+		&carserver.Action_VehicleAction{
+			VehicleAction: &carserver.VehicleAction{
+				VehicleActionMsg: &carserver.VehicleAction_VehicleControlSunroofOpenCloseAction{
+					VehicleControlSunroofOpenCloseAction: &carserver.VehicleControlSunroofOpenCloseAction{},
+				},
+			},
+		})
+}
+
 func (v *Vehicle) ChargePortClose(ctx context.Context) error {
 	return v.executeCarServerAction(ctx,
 		&carserver.Action_VehicleAction{

--- a/pkg/vehicle/infotainment.go
+++ b/pkg/vehicle/infotainment.go
@@ -99,6 +99,50 @@ func (v *Vehicle) ToggleMediaPlayback(ctx context.Context) error {
 		})
 }
 
+func (v *Vehicle) MediaNextFavorite(ctx context.Context) error {
+	return v.executeCarServerAction(ctx,
+		&carserver.Action_VehicleAction{
+			VehicleAction: &carserver.VehicleAction{
+				VehicleActionMsg: &carserver.VehicleAction_MediaNextFavorite{
+					MediaNextFavorite: &carserver.MediaNextFavorite{},
+				},
+			},
+		})
+}
+
+func (v *Vehicle) MediaPreviousFavorite(ctx context.Context) error {
+	return v.executeCarServerAction(ctx,
+		&carserver.Action_VehicleAction{
+			VehicleAction: &carserver.VehicleAction{
+				VehicleActionMsg: &carserver.VehicleAction_MediaPreviousFavorite{
+					MediaPreviousFavorite: &carserver.MediaPreviousFavorite{},
+				},
+			},
+		})
+}
+
+func (v *Vehicle) MediaNextTrack(ctx context.Context) error {
+	return v.executeCarServerAction(ctx,
+		&carserver.Action_VehicleAction{
+			VehicleAction: &carserver.VehicleAction{
+				VehicleActionMsg: &carserver.VehicleAction_MediaNextTrack{
+					MediaNextTrack: &carserver.MediaNextTrack{},
+				},
+			},
+		})
+}
+
+func (v *Vehicle) MediaPreviousTrack(ctx context.Context) error {
+	return v.executeCarServerAction(ctx,
+		&carserver.Action_VehicleAction{
+			VehicleAction: &carserver.VehicleAction{
+				VehicleActionMsg: &carserver.VehicleAction_MediaPreviousTrack{
+					MediaPreviousTrack: &carserver.MediaPreviousTrack{},
+				},
+			},
+		})
+}
+
 func (v *Vehicle) ScheduleSoftwareUpdate(ctx context.Context, delay time.Duration) error {
 	seconds := int32(delay / time.Second)
 	return v.executeCarServerAction(ctx,


### PR DESCRIPTION
# Description

This PR added this missing commands:

- media_next_fav
- media_next_track
- media_prev_fav
- media_prev_track
- sun_roof_control

related issue: #188 

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
