### PR TITLE
Allow serving tesla-http-proxy over http instead of https.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ tool](cmd/tesla-control) to start sending commands to your personal vehicle
 over BLE! Alternatively, continue reading below to learn how to build an
 application that can send commands over the Internet using a REST API.
 
+Note: if either of `TESLA_HTTP_PROXY_TLS_KEY` (`-tls-key`) or `TESLA_HTTP_PROXY_TLS_CERT` (`-cert`),
+are omitted the proxy will serve traffic over http instead of https.
+
 ## Using the HTTP proxy
 
 This section describes how to set up and use the HTTP proxy, which allows


### PR DESCRIPTION
This is a requirement to get it to run under Azure Container Apps, which has a health check on http traffic. It is also useful if you do your own TLS termination.

# Description

Since tesla-http-proxy forces serving under https, the premade docker image can't be used as-is in environments where http is mandated. This PR adds support for optionally not passing in TLS key and TLS cert. If any of those are empty, http will be used insead. The proxy will also say "Listening to http: <addr>:<port>" and "Listening to https: ..."

## Type of change

Please select all options that apply to this change:

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.
