### PR TITLE
Exposed log package to control level from apps

### DIFF
--- a/cmd/tesla-control/main.go
+++ b/cmd/tesla-control/main.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/google/shlex"
 
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/account"
 	"github.com/teslamotors/vehicle-command/pkg/cli"
 	"github.com/teslamotors/vehicle-command/pkg/connector/ble"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 	"github.com/teslamotors/vehicle-command/pkg/vehicle"
 )

--- a/cmd/tesla-http-proxy/main.go
+++ b/cmd/tesla-http-proxy/main.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/cli"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 	"github.com/teslamotors/vehicle-command/pkg/proxy"
 )

--- a/cmd/tesla-keygen/main.go
+++ b/cmd/tesla-keygen/main.go
@@ -15,8 +15,8 @@ import (
 	"path/filepath"
 
 	"github.com/teslamotors/vehicle-command/internal/authentication"
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/cli"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 )
 

--- a/examples/ble/main.go
+++ b/examples/ble/main.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 	"time"
 
-	debugger "github.com/teslamotors/vehicle-command/internal/log"
+	debugger "github.com/teslamotors/vehicle-command/pkg/log"
 
 	"github.com/teslamotors/vehicle-command/pkg/connector/ble"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"

--- a/internal/dispatcher/dispatcher.go
+++ b/internal/dispatcher/dispatcher.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/teslamotors/vehicle-command/internal/authentication"
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/connector"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 
 	"google.golang.org/protobuf/proto"

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 
 	"github.com/teslamotors/vehicle-command/internal/authentication"
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/cache"
 	"github.com/teslamotors/vehicle-command/pkg/connector"
 	"github.com/teslamotors/vehicle-command/pkg/connector/inet"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/vehicle"
 )
 

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -58,10 +58,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/account"
 	"github.com/teslamotors/vehicle-command/pkg/cache"
 	"github.com/teslamotors/vehicle-command/pkg/connector/ble"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 	"github.com/teslamotors/vehicle-command/pkg/vehicle"
 

--- a/pkg/connector/ble/ble.go
+++ b/pkg/connector/ble/ble.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/go-ble/ble"
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/connector"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 )
 

--- a/pkg/connector/ble/device_darwin.go
+++ b/pkg/connector/ble/device_darwin.go
@@ -3,7 +3,7 @@ package ble
 import (
 	"github.com/go-ble/ble"
 	"github.com/go-ble/ble/darwin"
-	"github.com/teslamotors/vehicle-command/internal/log"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 )
 
 func IsAdapterError(_ error) bool {

--- a/pkg/connector/inet/inet.go
+++ b/pkg/connector/inet/inet.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/connector"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 )
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -14,8 +14,8 @@ type Level int
 
 const (
 	LevelNone    Level = iota // Disables logging.
-	LevelError                // Logs anamolies that are not expected to occur during normal use.
-	LevelWarning              // Logs anamolies that are expected to occur occasionally during normal use.
+	LevelError                // Logs anomalies that are not expected to occur during normal use.
+	LevelWarning              // Logs anomalies that are expected to occur occasionally during normal use.
 	LevelInfo                 // Logs major events.
 	LevelDebug                // Logs detailed IO
 )

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/teslamotors/vehicle-command/internal/log"
 	"github.com/teslamotors/vehicle-command/pkg/account"
 	"github.com/teslamotors/vehicle-command/pkg/cache"
 	"github.com/teslamotors/vehicle-command/pkg/connector/inet"
+	"github.com/teslamotors/vehicle-command/pkg/log"
 	"github.com/teslamotors/vehicle-command/pkg/protocol"
 	"github.com/teslamotors/vehicle-command/pkg/sign"
 	"github.com/teslamotors/vehicle-command/pkg/vehicle"


### PR DESCRIPTION
# Description

When using the library as a package (like in the `ble` example), it is not possible to increase the log verbosity of the internal operations for debug.

It seems safe, since the logger package doesn't expose anything critical for the project. The `SetLevel` is what is required exactly.

The alternative is to expose such `SetLevel` from another package that is already public. However the current architecture doesn't offer a clear point in which this can be done.

Fixes # (issue)

## Type of change

Please select all options that apply to this change:

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update

# Checklist:

Confirm you have completed the following steps:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my code.
- [ ] I have made corresponding updates to the documentation.
- [ ] I have added/updated unit tests to cover my changes.

