### PR TITLE
http-proxy: add request id propagation for observability

### DIFF
--- a/cmd/tesla-http-proxy/request_id.go
+++ b/cmd/tesla-http-proxy/request_id.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+    "crypto/rand"
+    "encoding/hex"
+    "net/http"
+)
+
+func withRequestID(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        rid := r.Header.Get("X-Request-Id")
+        if rid == "" {
+            var b [16]byte
+            _, _ = rand.Read(b[:])
+            rid = hex.EncodeToString(b[:])
+        }
+        w.Header().Set("X-Request-Id", rid)
+        next.ServeHTTP(w, r)
+    })
+}

--- a/cmd/tesla-http-proxy/request_id_test.go
+++ b/cmd/tesla-http-proxy/request_id_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestRequestIDInjected(t *testing.T) {
+    h := withRequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+
+    req := httptest.NewRequest("GET", "/", nil)
+    rr := httptest.NewRecorder()
+    h.ServeHTTP(rr, req)
+
+    if rr.Header().Get("X-Request-Id") == "" {
+        t.Fatal("expected X-Request-Id header")
+    }
+}


### PR DESCRIPTION
Adds lightweight X-Request-Id propagation to tesla-http-proxy.

- Generates a request id when missing
- Preserves existing request ids if already present
- Improves traceability of vehicle command execution and error paths

No protocol, auth, or behavior changes.
