### PR TITLE
Added option to disabled TLS

### DIFF
--- a/cmd/tesla-http-proxy/main.go
+++ b/cmd/tesla-http-proxy/main.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	cacheSize   = 10000 // Number of cached vehicle sessions
-	defaultPort = 443
+	cacheSize = 10000 // Number of cached vehicle sessions
+	defaultPort = 8080
+	defaultPortHTTPS = 8443
 )
 
 const (
@@ -28,6 +29,7 @@ const (
 	EnvPort    = "TESLA_HTTP_PROXY_PORT"
 	EnvTimeout = "TESLA_HTTP_PROXY_TIMEOUT"
 	EnvVerbose = "TESLA_VERBOSE"
+	EnvDisableTLS = "TESLA_HTTP_PROXY_DISABLE_TLS"
 )
 
 const nonLocalhostWarning = `
@@ -119,17 +121,26 @@ func main() {
 		return
 	}
 
-	if tlsPublicKey, err := protocol.LoadPublicKey(httpConfig.keyFilename); err == nil {
-		if bytes.Equal(tlsPublicKey.Bytes(), skey.PublicBytes()) {
-			fmt.Fprintln(os.Stderr, "It is unsafe to use the same private key for TLS and command authentication.")
-			fmt.Fprintln(os.Stderr, "")
-			fmt.Fprintln(os.Stderr, "Generate a new TLS key for this server.")
-			return
+	// Check if TLS is disabled early
+	var useTLS bool = true
+	if disableTLS, ok := os.LookupEnv(EnvDisableTLS); ok {
+		useTLS = disableTLS != "true"
+	}
+
+	// Only validate TLS key if TLS is enabled
+	if useTLS {
+		if tlsPublicKey, err := protocol.LoadPublicKey(httpConfig.keyFilename); err == nil {
+			if bytes.Equal(tlsPublicKey.Bytes(), skey.PublicBytes()) {
+				fmt.Fprintln(os.Stderr, "It is unsafe to use the same private key for TLS and command authentication.")
+				fmt.Fprintln(os.Stderr, "")
+				fmt.Fprintln(os.Stderr, "Generate a new TLS key for this server.")
+				return
+			}
+			log.Debug("Verified that TLS key is not the same as the command-authentication key.")
+		} else {
+			// Discarding the error here is deliberate
+			log.Debug("Verified that TLS key is not a recycled command-authentication key, because it is not NIST P256.")
 		}
-		log.Debug("Verified that TLS key is not the same as the command-authentication key.")
-	} else {
-		// Discarding the error here is deliberate
-		log.Debug("Verified that TLS key is not a recycled command-authentication key, because it is not NIST P256.")
 	}
 
 	log.Debug("Creating proxy")
@@ -142,12 +153,11 @@ func main() {
 	addr := fmt.Sprintf("%s:%d", httpConfig.host, httpConfig.port)
 	log.Info("Listening on %s", addr)
 
-	// To add more application logic requests, such as alternative client authentication, create
-	// a http.HandleFunc implementation (https://pkg.go.dev/net/http#HandlerFunc). The ServeHTTP
-	// method of your implementation can perform your business logic and then, if the request is
-	// authorized, invoke p.ServeHTTP. Finally, replace p in the below ListenAndServeTLS call with
-	// an object of your newly created type.
-	log.Error("Server stopped: %s", http.ListenAndServeTLS(addr, httpConfig.certFilename, httpConfig.keyFilename, p))
+	if useTLS && httpConfig.certFilename != "" && httpConfig.keyFilename != "" {
+		log.Error("Server stopped: %s", http.ListenAndServeTLS(addr, httpConfig.certFilename, httpConfig.keyFilename, p))
+	} else {
+		log.Error("Server stopped: %s", http.ListenAndServe(addr, p))
+	}
 }
 
 // readConfig applies configuration from environment variables.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,16 @@ services:
   tesla_http_proxy:
     image: tesla/vehicle-command:latest
     ports:
-      - "4443:4443"
+      - "8080:8080"
     environment:
       - TESLA_HTTP_PROXY_TLS_CERT=/config/tls-cert.pem
       - TESLA_HTTP_PROXY_TLS_KEY=/config/tls-key.pem
       - TESLA_HTTP_PROXY_HOST=0.0.0.0
-      - TESLA_HTTP_PROXY_PORT=4443
+      - TESLA_HTTP_PROXY_PORT=8080
       - TESLA_HTTP_PROXY_TIMEOUT=10s
       - TESLA_KEY_FILE=/config/fleet-key.pem
       - TESLA_VERBOSE=true
+      - TESLA_HTTP_PROXY_DISABLE_TLS=true
     security_opt:
       - no-new-privileges:true
     volumes:


### PR DESCRIPTION
TLS can be safely disabled in our case because the http endpoints will be behind Azure Container App's ingress.