### PR TITLE
pkg/protocol: re-export Session alias for external HSM integrations

### DIFF
--- a/pkg/protocol/external_impl_test.go
+++ b/pkg/protocol/external_impl_test.go
@@ -1,0 +1,40 @@
+package protocol_test
+
+import (
+	"hash"
+	"testing"
+
+	"github.com/teslamotors/vehicle-command/pkg/protocol"
+)
+
+// externalKey is a no-op stub that satisfies protocol.ECDHPrivateKey from a
+// package outside the vehicle-command module. The point of this test is purely
+// structural: it would not compile prior to the Session alias being added,
+// because the Exchange return type (authentication.Session) was not nameable
+// from external code.
+type externalKey struct{}
+
+func (e *externalKey) PublicBytes() []byte                              { return nil }
+func (e *externalKey) SchnorrSignature(message []byte) ([]byte, error)  { return nil, nil }
+func (e *externalKey) Exchange(remotePublicBytes []byte) (protocol.Session, error) {
+	return &externalSession{}, nil
+}
+
+type externalSession struct{}
+
+func (e *externalSession) SessionInfoHMAC(id, challenge, encodedInfo []byte) ([]byte, error) {
+	return nil, nil
+}
+func (e *externalSession) Encrypt(plaintext, associatedData []byte) ([]byte, []byte, []byte, error) {
+	return nil, nil, nil, nil
+}
+func (e *externalSession) Decrypt(nonce, ciphertext, associatedData, tag []byte) ([]byte, error) {
+	return nil, nil
+}
+func (e *externalSession) LocalPublicBytes() []byte    { return nil }
+func (e *externalSession) NewHMAC(label string) hash.Hash { return nil }
+
+func TestExternalECDHPrivateKeyImplementation(t *testing.T) {
+	var _ protocol.ECDHPrivateKey = (*externalKey)(nil)
+	var _ protocol.Session = (*externalSession)(nil)
+}

--- a/pkg/protocol/external_impl_test.go
+++ b/pkg/protocol/external_impl_test.go
@@ -14,8 +14,8 @@ import (
 // from external code.
 type externalKey struct{}
 
-func (e *externalKey) PublicBytes() []byte                              { return nil }
-func (e *externalKey) SchnorrSignature(message []byte) ([]byte, error)  { return nil, nil }
+func (e *externalKey) PublicBytes() []byte                             { return nil }
+func (e *externalKey) SchnorrSignature(message []byte) ([]byte, error) { return nil, nil }
 func (e *externalKey) Exchange(remotePublicBytes []byte) (protocol.Session, error) {
 	return &externalSession{}, nil
 }
@@ -31,7 +31,7 @@ func (e *externalSession) Encrypt(plaintext, associatedData []byte) ([]byte, []b
 func (e *externalSession) Decrypt(nonce, ciphertext, associatedData, tag []byte) ([]byte, error) {
 	return nil, nil
 }
-func (e *externalSession) LocalPublicBytes() []byte    { return nil }
+func (e *externalSession) LocalPublicBytes() []byte       { return nil }
 func (e *externalSession) NewHMAC(label string) hash.Hash { return nil }
 
 func TestExternalECDHPrivateKeyImplementation(t *testing.T) {

--- a/pkg/protocol/external_impl_test.go
+++ b/pkg/protocol/external_impl_test.go
@@ -14,27 +14,27 @@ import (
 // from external code.
 type externalKey struct{}
 
-func (e *externalKey) PublicBytes() []byte                             { return nil }
-func (e *externalKey) SchnorrSignature(message []byte) ([]byte, error) { return nil, nil }
-func (e *externalKey) Exchange(remotePublicBytes []byte) (protocol.Session, error) {
+func (e *externalKey) PublicBytes() []byte                       { return nil }
+func (e *externalKey) SchnorrSignature(_ []byte) ([]byte, error) { return nil, nil }
+func (e *externalKey) Exchange(_ []byte) (protocol.Session, error) {
 	return &externalSession{}, nil
 }
 
 type externalSession struct{}
 
-func (e *externalSession) SessionInfoHMAC(id, challenge, encodedInfo []byte) ([]byte, error) {
+func (e *externalSession) SessionInfoHMAC(_, _, _ []byte) ([]byte, error) {
 	return nil, nil
 }
-func (e *externalSession) Encrypt(plaintext, associatedData []byte) ([]byte, []byte, []byte, error) {
+func (e *externalSession) Encrypt(_, _ []byte) ([]byte, []byte, []byte, error) {
 	return nil, nil, nil, nil
 }
-func (e *externalSession) Decrypt(nonce, ciphertext, associatedData, tag []byte) ([]byte, error) {
+func (e *externalSession) Decrypt(_, _, _, _ []byte) ([]byte, error) {
 	return nil, nil
 }
-func (e *externalSession) LocalPublicBytes() []byte       { return nil }
-func (e *externalSession) NewHMAC(label string) hash.Hash { return nil }
+func (e *externalSession) LocalPublicBytes() []byte   { return nil }
+func (e *externalSession) NewHMAC(_ string) hash.Hash { return nil }
 
-func TestExternalECDHPrivateKeyImplementation(t *testing.T) {
+func TestExternalECDHPrivateKeyImplementation(_ *testing.T) {
 	var _ protocol.ECDHPrivateKey = (*externalKey)(nil)
 	var _ protocol.Session = (*externalSession)(nil)
 }

--- a/pkg/protocol/key.go
+++ b/pkg/protocol/key.go
@@ -17,6 +17,20 @@ import (
 
 type ECDHPrivateKey authentication.ECDHPrivateKey
 
+// Session is a type alias for authentication.Session, exposed here so that
+// external packages can implement ECDHPrivateKey. The Exchange method on
+// ECDHPrivateKey returns Session, and without this alias external code cannot
+// reference the return type of that method, which makes ECDHPrivateKey
+// effectively unimplementable from outside this module.
+//
+// This matters for HSM and enclave integrations: code that holds the private
+// key in protected memory (Nitro Enclave, KMS, hardware HSM) needs to provide
+// its own ECDHPrivateKey implementation that proxies to the protected boundary.
+// The package comment in internal/authentication/ecdh.go specifically calls
+// out HSM integration as the reason ECDHPrivateKey is an interface rather
+// than a concrete type, so re-exporting Session restores that capability.
+type Session = authentication.Session
+
 // LoadPrivateKey loads a P256 EC private key from a file.
 func LoadPrivateKey(filename string) (ECDHPrivateKey, error) {
 	return authentication.LoadExternalECDHKey(filename)

--- a/pkg/protocol/key.go
+++ b/pkg/protocol/key.go
@@ -15,6 +15,10 @@ import (
 
 // Expose some interfaces from the otherwise internal package
 
+// ECDHPrivateKey represents a local private key.
+//
+// See warnings in [Session] if implementing this interface using an HSM or
+// other Trusted Execution Environment (TEE).
 type ECDHPrivateKey authentication.ECDHPrivateKey
 
 // Session is a type alias for authentication.Session, exposed here so that
@@ -29,6 +33,28 @@ type ECDHPrivateKey authentication.ECDHPrivateKey
 // The package comment in internal/authentication/ecdh.go specifically calls
 // out HSM integration as the reason ECDHPrivateKey is an interface rather
 // than a concrete type, so re-exporting Session restores that capability.
+//
+// If this interface is implemented using an HSM or other trusted execution
+// environment (TEE), then protecting long-term key material from a host
+// compromise requires:
+//
+//   - The TEE must NOT expose an API to export the shared secret (i.e., an
+//     ECDH interface).
+//   - The TEE must NOT expose an AES interface that uses the ECDH-derived
+//     key. This would allow a compromised host to compute the derived
+//     AES-GCM integrity-protection key.
+//   - The TEE must NOT expose an AES-GCM encryption interface that accepts
+//     the nonce as a host-provided input. Again, this would allow a
+//     compromised host to compute the derived AES-GCM integrity-protection
+//     key.
+//
+// The Session object should not include any of the above derived secrets,
+// just handles that can be provided to the TEE.
+//
+// If the TEE interface cannot meet the above requirements, then there may
+// still be value in using one because the host will only be able to
+// exfiltrate long-term shared secrets for existing, known vehicle public
+// keys.
 type Session = authentication.Session
 
 // LoadPrivateKey loads a P256 EC private key from a file.


### PR DESCRIPTION
# Description

Adds a single type alias `type Session = authentication.Session` to
`pkg/protocol/key.go`, alongside the existing `ECDHPrivateKey` alias.
Includes a structural test in a `protocol_test` external package that
demonstrates an external implementation of `ECDHPrivateKey` + `Session`;
that test would not compile prior to this change.

# Motivation

The package comment in `internal/authentication/ecdh.go` states that
`ECDHPrivateKey` is an interface specifically to enable HSM integrations:

> The crypto/ecdh package and github.com/aead/ecdh.KeyExchange interface
> aren't safe to use with static keys if you want to implement with an HSM.
> The interface would divulge long-term secrets to a compromised host machine.

However, `ECDHPrivateKey.Exchange` returns `authentication.Session`, and
Go's `internal/` rule prevents external packages from naming that type.
The result is that no code outside this module can implement
`ECDHPrivateKey` in pure Go, which defeats the documented design intent
— any external HSM integration currently requires a fork of this repository.

Re-exporting `Session` via a type alias in `pkg/protocol` (where
`ECDHPrivateKey` is already re-exported the same way) restores external
implementability without otherwise changing the public API.

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] My code follows the style of this project.
- [x] I have performed a self-review of my code.
- [x] I have added unit tests to cover my changes.
- [x] I have made corresponding updates to the documentation. *(no doc changes needed — the alias is self-describing alongside the existing ECDHPrivateKey alias and has a doc comment explaining its purpose)*