### PR TITLE
tesla-control: honor ID argument in charging-schedule-add

### DIFF
--- a/cmd/tesla-control/commands.go
+++ b/cmd/tesla-control/commands.go
@@ -1074,6 +1074,14 @@ var commands = map[string]*Command{
 				schedule.Enabled = enabledStr == "true"
 			}
 
+			if idStr, ok := args["ID"]; ok {
+				id, err := strconv.ParseUint(idStr, 10, 64)
+				if err != nil {
+					return errors.New("expected numeric ID")
+				}
+				schedule.Id = id
+			}
+
 			schedule.DaysOfWeek, err = GetDays(args["DAYS"])
 			if err != nil {
 				return err


### PR DESCRIPTION
The `charging-schedule-add` command lists an optional `ID` argument with the help text "The ID of the charge schedule to modify. Not required for new schedules." However the handler never reads `args["ID"]`. It unconditionally sets the schedule ID to the current Unix timestamp:

```go
schedule := vehicle.ChargeSchedule{
    Id:      uint64(time.Now().Unix()),
    Enabled: true,
}
```

So passing an ID to update an existing charge schedule silently creates a new one instead, and the printed ID is the timestamp rather than the one the user supplied.

The two analogous code paths both handle this correctly:

- `precondition-schedule-add` parses `args["ID"]` and overrides the timestamp when present.
- The HTTP proxy `add_charge_schedule` handler in `pkg/proxy/command.go` reads `id` and only falls back to `time.Now().Unix()` when it is `0`.

This change applies the same parsing to `charging-schedule-add`, matching the precondition handler verbatim. When `ID` is omitted the behavior is unchanged (timestamp ID for a new schedule).