### PR TITLE
proxy: return after writing max-retry-exhausted error

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -277,6 +277,7 @@ func (p *Proxy) forwardRequest(acct *account.Account, w http.ResponseWriter, req
 		attempts++
 		if attempts == MaxAttempts {
 			writeJSONError(w, http.StatusBadGateway, protocol.NewError("max retry exhausted", false, false))
+			return
 		}
 
 		log.Debug("Retrying transmission after error...")


### PR DESCRIPTION
## Problem

In `forwardRequest`'s retry loop (`pkg/proxy/proxy.go`), when `attempts` reaches `MaxAttempts` the proxy writes a 502 `max retry exhausted` response — but does not `return`:

```go
attempts++
if attempts == MaxAttempts {
    writeJSONError(w, http.StatusBadGateway, protocol.NewError("max retry exhausted", false, false))
}

log.Debug("Retrying transmission after error...")
```

Two consequences:

1. After telling the client it gave up, the loop sleeps 1s and **retries anyway**.
2. Because the guard is `==` rather than `>=`, once `attempts` passes `MaxAttempts` it can never fire again — so the loop keeps retrying until the request context expires, at which point `writeJSONError(w, http.StatusGatewayTimeout, ...)` writes a **second** response on top of the 502 already sent (`http: superfluous response.WriteHeader call`).

## Fix

Add `return` after the error is written, matching every other error path in the loop.

`go build ./...`, `go vet ./pkg/proxy/`, and `go test ./pkg/proxy/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)