### PR TITLE
Fix help strings, doc comments, and usage text

### DIFF
--- a/cmd/tesla-control/commands.go
+++ b/cmd/tesla-control/commands.go
@@ -379,7 +379,7 @@ var commands = map[string]*Command{
 		},
 	},
 	"add-key-request": {
-		help:             "Request NFC-card approval for a enrolling PUBLIC_KEY with ROLE and FORM_FACTOR",
+		help:             "Request NFC-card approval for an enrolling PUBLIC_KEY with ROLE and FORM_FACTOR",
 		requiresAuth:     false,
 		requiresFleetAPI: false,
 		args: []Argument{
@@ -423,7 +423,7 @@ var commands = map[string]*Command{
 		},
 	},
 	"rename-key": {
-		help:             "Change the human-readable metadata of PUBLIC_KEY to NAME, MODEL, KIND",
+		help:             "Change the human-readable name of PUBLIC_KEY to NAME",
 		requiresAuth:     false,
 		requiresFleetAPI: true,
 		args: []Argument{
@@ -655,7 +655,7 @@ var commands = map[string]*Command{
 		requiresAuth:     true,
 		requiresFleetAPI: false,
 		args: []Argument{
-			{name: "VOLUME", help: "Set volume (0.0-10.0"},
+			{name: "VOLUME", help: "Set volume (0.0-10.0)"},
 		},
 		handler: func(ctx context.Context, _ *account.Account, car *vehicle.Vehicle, args map[string]string) error {
 			volume, err := strconv.ParseFloat(args["VOLUME"], 32)
@@ -867,7 +867,6 @@ var commands = map[string]*Command{
 			{name: "DOMAIN", help: "'vcsec' or 'infotainment'"},
 		},
 		handler: func(ctx context.Context, _ *account.Account, car *vehicle.Vehicle, args map[string]string) error {
-			// See SeatPosition definition for controlling backrest heaters (limited models).
 			domains := map[string]protocol.Domain{
 				"vcsec":        protocol.DomainVCSEC,
 				"infotainment": protocol.DomainInfotainment,
@@ -889,7 +888,7 @@ var commands = map[string]*Command{
 		},
 	},
 	"seat-heater": {
-		help:             "Set seat heater at POSITION to LEVEL",
+		help:             "Set seat heater at SEAT to LEVEL",
 		requiresAuth:     true,
 		requiresFleetAPI: false,
 		args: []Argument{

--- a/cmd/tesla-keygen/main.go
+++ b/cmd/tesla-keygen/main.go
@@ -31,7 +31,7 @@ plaintext file into the system keyring.
 
 The program writes the public key to stdout (except when deleting a key or setting the output
 location with -output). When using the create option, the program will not overwrite an existing
-unless invoked with -f.
+key unless invoked with -f.
 
 The type of keyring and name of the key inside that keyring are controlled by the command-line
 options below, or through the corresponding environment variables.`

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -9,7 +9,7 @@ import (
 type AuthMethod int32
 
 const (
-	// AuthMethodNone commnds are unauthenticated. They are typically used for handshake messages.
+	// AuthMethodNone commands are unauthenticated. They are typically used for handshake messages.
 	AuthMethodNone AuthMethod = iota
 
 	// AuthMethodGCM commands are authenticated and encrypted with AES-GCM-ECDH.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -366,7 +366,7 @@ func (p *Proxy) handleFleetTelemetryConfig(acct *account.Account, w http.Respons
 
 	// Let the server validate the VINs and config, the proxy just needs to sign
 	if _, ok := params.Config["aud"]; ok {
-		log.Warning("Confuration 'aud' field will be overwritten")
+		log.Warning("Configuration 'aud' field will be overwritten")
 	}
 	if _, ok := params.Config["iss"]; ok {
 		log.Warning("Configuration 'iss' field will be overwritten")

--- a/pkg/vehicle/actions.go
+++ b/pkg/vehicle/actions.go
@@ -23,7 +23,7 @@ func (v *Vehicle) CloseTrunk(ctx context.Context) error {
 	return v.executeClosureAction(ctx, vcsec.ClosureMoveType_E_CLOSURE_MOVE_TYPE_CLOSE, ClosureTrunk)
 }
 
-// OpenTrunk opens the frunk. There is no remote way to close the frunk!
+// OpenFrunk opens the frunk. There is no remote way to close the frunk!
 func (v *Vehicle) OpenFrunk(ctx context.Context) error {
 	return v.executeClosureAction(ctx, vcsec.ClosureMoveType_E_CLOSURE_MOVE_TYPE_MOVE, ClosureFrunk)
 }


### PR DESCRIPTION
User-visible text fixes, each verified against the code (no behavior changes):

| Location | Issue |
|---|---|
| `tesla-control rename-key` help | Promises "NAME, MODEL, KIND", but the command accepts only `PUBLIC_KEY` and `NAME`, and the handler passes only the name to `Account.UpdateKey` |
| `tesla-control seat-heater` help | Says "at POSITION"; the argument is named `SEAT` |
| `tesla-control volume` VOLUME help | Unclosed parenthesis: `(0.0-10.0` |
| `tesla-control add-key-request` help | "a enrolling" → "an enrolling" |
| `tesla-control session-info` handler | Stray copy of the seat-heater backrest comment at the top of the handler |
| `tesla-keygen` usage text | Dropped word: "will not overwrite an existing ~~ ~~ unless invoked with `-f`" → "an existing key" |
| `Vehicle.OpenFrunk` godoc | Comment names `OpenTrunk` (copy-paste); renders wrong on pkg.go.dev |
| `pkg/proxy` telemetry-config warning | "Confuration" → "Configuration" (the parallel `iss` warning three lines below is spelled correctly) |
| `AuthMethodNone` doc comment | "commnds" → "commands" |

`go build ./...` and `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)