### PR TITLE
protocol: set FLAG_ENCRYPT_RESPONSE in the AES-GCM documentation example

### DIFF
--- a/internal/authentication/protocol_doc_test.go
+++ b/internal/authentication/protocol_doc_test.go
@@ -1,0 +1,89 @@
+package authentication
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/teslamotors/vehicle-command/pkg/protocol/protobuf/signatures"
+	universal "github.com/teslamotors/vehicle-command/pkg/protocol/protobuf/universalmessage"
+)
+
+func mustDecodeHex(t *testing.T, value string) []byte {
+	t.Helper()
+	data, err := hex.DecodeString(value)
+	if err != nil {
+		t.Fatalf("invalid hex %q: %s", value, err)
+	}
+	return data
+}
+
+// TestProtocolDocAESGCMExample pins the worked AES-GCM encryption example in
+// pkg/protocol/protocol.md (under "Authorizing commands"). If this test fails,
+// the implementation and the documentation have drifted apart, and the example
+// values in protocol.md need to be regenerated.
+func TestProtocolDocAESGCMExample(t *testing.T) {
+	const (
+		docVIN        = "5YJ30123456789ABC"
+		docEpoch      = "4c463f9cc0d3d26906e982ed224adde6"
+		docExpiresAt  = 2655
+		docCounter    = 7
+		docMetadata   = "000105010103021135594a333031323334353637383941424303104c463f9cc0d3d26906e982ed224adde6040400000a5f050400000007070400000002ff"
+		docKey        = "1b2fce19967b79db696f909cff89ea9a"
+		docNonce      = "dbf79447fa156674dae1caed"
+		docPlaintext  = "120452020801"
+		docCiphertext = "38038e8c0f2e"
+		docTag        = "c228e0ff64991481db3a7bbc133696c5"
+	)
+
+	meta := newMetadata()
+	if err := meta.Add(signatures.Tag_TAG_SIGNATURE_TYPE, []byte{byte(signatures.SignatureType_SIGNATURE_TYPE_AES_GCM_PERSONALIZED)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := meta.Add(signatures.Tag_TAG_DOMAIN, []byte{byte(universal.Domain_DOMAIN_INFOTAINMENT)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := meta.Add(signatures.Tag_TAG_PERSONALIZATION, []byte(docVIN)); err != nil {
+		t.Fatal(err)
+	}
+	if err := meta.Add(signatures.Tag_TAG_EPOCH, mustDecodeHex(t, docEpoch)); err != nil {
+		t.Fatal(err)
+	}
+	if err := meta.AddUint32(signatures.Tag_TAG_EXPIRES_AT, docExpiresAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := meta.AddUint32(signatures.Tag_TAG_COUNTER, docCounter); err != nil {
+		t.Fatal(err)
+	}
+	if err := meta.AddUint32(signatures.Tag_TAG_FLAGS, 1<<universal.Flags_FLAG_ENCRYPT_RESPONSE); err != nil {
+		t.Fatal(err)
+	}
+
+	aad := meta.Checksum(nil)
+	expectedAAD := sha256.Sum256(mustDecodeHex(t, docMetadata))
+	if !bytes.Equal(aad, expectedAAD[:]) {
+		t.Error("metadata serialization diverges from the byte string in protocol.md")
+	}
+
+	block, err := aes.NewCipher(mustDecodeHex(t, docKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed := gcm.Seal(nil, mustDecodeHex(t, docNonce), mustDecodeHex(t, docPlaintext), aad)
+
+	ciphertext := sealed[:len(sealed)-gcm.Overhead()]
+	tag := sealed[len(sealed)-gcm.Overhead():]
+	if got := hex.EncodeToString(ciphertext); got != docCiphertext {
+		t.Errorf("ciphertext diverges from protocol.md: got %s, want %s", got, docCiphertext)
+	}
+	if got := hex.EncodeToString(tag); got != docTag {
+		t.Errorf("tag diverges from protocol.md: got %s, want %s", got, docTag)
+	}
+}

--- a/pkg/protocol/protocol.md
+++ b/pkg/protocol/protocol.md
@@ -596,7 +596,11 @@ To encrypt the plaintext protobuf `P` using AES-GCM:
 
 ***Example:*** We'll send an "Turn HVAC on" command using the above example
 with `VIN = 5YJ30123456789ABC` and the hex representation of the shared key `K
-= 1b2fce19967b79db696f909cff89ea9a`.
+= 1b2fce19967b79db696f909cff89ea9a`. The request sets the
+`UniversalMessage.FLAG_ENCRYPT_RESPONSE` flag, as recommended for all commands
+(see [Response decryption](#response-decryption)), so the flags bit mask is `1
+<< FLAG_ENCRYPT_RESPONSE = 2` and is included in both the metadata and the
+`RoutableMessage.flags` field.
 
 First we find the protobuf encoding for the command. Normally this is done
 using the language-specific bindings created by `protoc` from the `*.proto`
@@ -624,11 +628,15 @@ field of AES-GCM.
 |  `Signatures.TAG_EPOCH`          | `session_info.epoch`   | 03 10 4c463f9cc0d3d26906e982ed224adde6    |
 |  `Signatures.TAG_EXPIRES_AT`     | `t=2655` seconds       | 04 04 00000a5f                            |
 |  `Signatures.TAG_COUNTER`        | `session_info.counter` | 05 04 00000007                            |
+|  `Signatures.TAG_FLAGS`          | `1 << UniversalMessage.FLAG_ENCRYPT_RESPONSE = 0x02` | 07 04 00000002 |
+
+All values in the Encoding column are hex, including the leading tag and
+length bytes.
 
 Concatenating the above encoded values together with the terminal `0xff` byte gives:
 
 ```
-000105010103021135594a333031323334353637383941424303104c463f9cc0d3d26906e982ed224adde6040400000a5f050400000007ff
+000105010103021135594a333031323334353637383941424303104c463f9cc0d3d26906e982ed224adde6040400000a5f050400000007070400000002ff
 ```
 
 ```python
@@ -638,7 +646,7 @@ from cryptography.hazmat.primitives import hashes
 
 plaintext = bytes.fromhex("120452020801")
 
-metadata = bytes.fromhex("000105010103021135594a333031323334353637383941424303104c463f9cc0d3d26906e982ed224adde6040400000a5f050400000007ff")
+metadata = bytes.fromhex("000105010103021135594a333031323334353637383941424303104c463f9cc0d3d26906e982ed224adde6040400000a5f050400000007070400000002ff")
 aad = hashes.Hash(hashes.SHA256())
 
 aad.update(metadata)
@@ -653,7 +661,7 @@ print(f"Nonce: {nonce.hex()}, Ciphertext: {ct[:-16].hex()}, Tag: {ct[-16:].hex()
 Output (will be randomized each time by the nonce):
 
 ```
-Nonce: dbf79447fa156674dae1caed, Ciphertext: 38038e8c0f2e, Tag: 8e128da165f162f4d7d2c8da866cf82a
+Nonce: dbf79447fa156674dae1caed, Ciphertext: 38038e8c0f2e, Tag: c228e0ff64991481db3a7bbc133696c5
 ```
 
 Copying the above fields into a RoutableMessage protobuf yields:
@@ -675,9 +683,10 @@ signature_data {
     nonce: dbf79447fa156674dae1caed
     counter: 7
     expires_at: 2655
-    tag: 8e128da165f162f4d7d2c8da866cf82a
+    tag: c228e0ff64991481db3a7bbc133696c5
   }
 }
+flags: 2
 uuid: 58406580528b6a5301391800b4fe9b99
 ```
 


### PR DESCRIPTION
## Problem

In #401, @sethterashima noted that the worked AES-GCM example in `pkg/protocol/protocol.md` predates `FLAG_ENCRYPT_RESPONSE` and was never regenerated after the flag was introduced, even though setting it is recommended for all commands: "The documentation examples should be updated to reflect this recommendation." The issue was left open as a reminder for that update.

## Changes

**`pkg/protocol/protocol.md`** — the example now sets `FLAG_ENCRYPT_RESPONSE`:
- The metadata table gains the `TAG_FLAGS` row (`1 << FLAG_ENCRYPT_RESPONSE = 0x02`, encoded `07 04 00000002`), and the intro sentence explains why the flag is set, linking to [Response decryption](https://github.com/teslamotors/vehicle-command/blob/main/pkg/protocol/protocol.md#response-decryption).
- The serialized metadata string and Python snippet are extended accordingly.
- The authentication tag is recomputed: `c228e0ff64991481db3a7bbc133696c5` (same key/nonce/plaintext; the ciphertext `38038e8c0f2e` is unchanged because GCM associated data only affects the tag).
- The `RoutableMessage` dump gains `flags: 2`.
- Added a note that the Encoding column values are hex, including tag and length bytes — the other point of confusion in the issue.

**`internal/authentication/protocol_doc_test.go`** — a new test pins the documented example to the implementation: it rebuilds the metadata with the package's own serializer (`newMetadata` / `Add` / `AddUint32` / `Checksum`), asserts the AAD matches the documented byte string, and verifies the ciphertext and tag. If the doc and implementation drift apart again, this test fails and points at the example.

## Verification

- The pipeline first reproduced the *old* documented tag (`8e128da165f162f4d7d2c8da866cf82a`) with the flag omitted, confirming the regeneration method matches whatever produced the original example.
- `go test ./internal/authentication/` and `go vet` pass.
- Removing the `TAG_FLAGS` line from the test makes both the metadata and tag assertions fail, so the test genuinely pins the flag's inclusion.

Fixes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)