### PR TITLE
proxy: return 408 for asleep vehicles and 412 for unpaired keys

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -130,6 +130,22 @@ type carResponse struct {
 	Reason string `json:"reason"`
 }
 
+// httpStatusCode maps errors to the HTTP status codes Fleet API uses for the
+// equivalent failures, defaulting to 500 for unrecognized errors.
+func httpStatusCode(err error) int {
+	switch {
+	case errors.Is(err, inet.ErrVehicleNotAwake):
+		// Fleet API returns 408 when the vehicle is offline or asleep.
+		return http.StatusRequestTimeout
+	case errors.Is(err, protocol.ErrKeyNotPaired):
+		// Not 401: the OAuth token was accepted, but the vehicle-side key
+		// pairing precondition failed.
+		return http.StatusPreconditionFailed
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
 func writeJSONError(w http.ResponseWriter, code int, err error) {
 	reply := Response{}
 
@@ -414,7 +430,7 @@ func (p *Proxy) handleVehicleCommand(acct *account.Account, w http.ResponseWrite
 	}
 
 	if err := car.Connect(ctx); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err)
+		writeJSONError(w, httpStatusCode(err), err)
 		return err
 	}
 	defer car.Disconnect()
@@ -424,7 +440,7 @@ func (p *Proxy) handleVehicleCommand(acct *account.Account, w http.ResponseWrite
 		p.forwardRequest(acct, w, req)
 		return err
 	} else if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err)
+		writeJSONError(w, httpStatusCode(err), err)
 		return err
 	}
 	defer func() {
@@ -439,7 +455,7 @@ func (p *Proxy) handleVehicleCommand(acct *account.Account, w http.ResponseWrite
 		return err
 	}
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err)
+		writeJSONError(w, httpStatusCode(err), err)
 		return err
 	}
 

--- a/pkg/proxy/status_test.go
+++ b/pkg/proxy/status_test.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/teslamotors/vehicle-command/pkg/connector/inet"
+	"github.com/teslamotors/vehicle-command/pkg/protocol"
+)
+
+func TestHTTPStatusCode(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected int
+	}{
+		{"vehicle asleep", inet.ErrVehicleNotAwake, http.StatusRequestTimeout},
+		{"vehicle asleep wrapped", fmt.Errorf("connect: %w", inet.ErrVehicleNotAwake), http.StatusRequestTimeout},
+		{"key not paired", protocol.ErrKeyNotPaired, http.StatusPreconditionFailed},
+		{"key not paired wrapped", fmt.Errorf("handshake: %w", protocol.ErrKeyNotPaired), http.StatusPreconditionFailed},
+		{"generic error", errors.New("boom"), http.StatusInternalServerError},
+		{"deadline exceeded", context.DeadlineExceeded, http.StatusInternalServerError},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if code := httpStatusCode(testCase.err); code != testCase.expected {
+				t.Errorf("httpStatusCode(%v) = %d, want %d", testCase.err, code, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestWriteJSONErrorStatus(t *testing.T) {
+	// Mapped errors reach the client with the mapped status code and the
+	// error message in the JSON error field.
+	recorder := httptest.NewRecorder()
+	writeJSONError(recorder, httpStatusCode(inet.ErrVehicleNotAwake), inet.ErrVehicleNotAwake)
+	if recorder.Code != http.StatusRequestTimeout {
+		t.Errorf("vehicle-asleep status = %d, want %d", recorder.Code, http.StatusRequestTimeout)
+	}
+	var reply struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &reply); err != nil {
+		t.Fatalf("invalid JSON body %q: %s", recorder.Body.String(), err)
+	}
+	if reply.Error != inet.ErrVehicleNotAwake.Error() {
+		t.Errorf("error field = %q, want %q", reply.Error, inet.ErrVehicleNotAwake.Error())
+	}
+
+	// An inet.HTTPError still passes its own status code through, regardless
+	// of the code computed by the caller.
+	httpErr := &inet.HTTPError{Code: http.StatusTooManyRequests, Message: `{"error":"slow down"}`}
+	recorder = httptest.NewRecorder()
+	writeJSONError(recorder, httpStatusCode(httpErr), httpErr)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Errorf("HTTPError status = %d, want %d", recorder.Code, http.StatusTooManyRequests)
+	}
+
+	// Nominal errors still return 200 with the reason in the response body.
+	recorder = httptest.NewRecorder()
+	writeJSONError(recorder, http.StatusOK, &protocol.NominalError{Details: errors.New("could not execute command")})
+	if recorder.Code != http.StatusOK {
+		t.Errorf("nominal error status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}


### PR DESCRIPTION
## Problem

#226 reports that the proxy returns HTTP 500 with bodies like `{"error":"vehicle unavailable: vehicle is offline or asleep"}` and `{"error":"vehicle rejected request: your public key has not been paired with the vehicle"}`, where more specific status codes would let clients build error handling without string-matching bodies.

The cause: `writeJSONError` handles `inet.HTTPError` (passes its own code through) and nominal errors (200), but every other command failure gets a hardcoded `http.StatusInternalServerError` at its call sites in `handleVehicleCommand`.

The offline case is doubly wrong: `inet.SendFleetAPICommand` *derives* `ErrVehicleNotAwake` from Fleet API's own 408 response ("vehicle is offline"), so the proxy takes a documented 408 and converts it into a 500 — breaking parity with the API it fronts.

## Changes

Add an `httpStatusCode` helper and use it at the three call sites that previously hardcoded 500 (`Connect`, `StartSession`, and command execution):

- `inet.ErrVehicleNotAwake` → **408 Request Timeout**, matching Fleet API's documented behavior for offline/asleep vehicles (and restoring the code the connector originally received).
- `protocol.ErrKeyNotPaired` → **412 Precondition Failed**. The issue suggested 401 or 412; 412 is the better fit because the OAuth bearer token *was* accepted — it's the vehicle-side key-pairing precondition that failed, and 401 would misdirect users toward refreshing tokens.
- Everything else remains 500, including `context.DeadlineExceeded`, which the issue reporter agreed is a legitimate 500.

Unchanged and now pinned by tests: nominal errors → 200 with the reason in the response body, and `inet.HTTPError` passing its own code through. The 503-on-lock-timeout and 504-on-forward-timeout paths are untouched.

## Tests

New `pkg/proxy/status_test.go` (first coverage for the error→status mapping):
- table-driven `httpStatusCode` cases, including `%w`-wrapped variants of both sentinels (they're returned bare today from `GetError`/`inet`, but wrapping must not break the mapping),
- end-to-end `writeJSONError` checks via `httptest`: mapped status + JSON error body for the asleep case, `HTTPError` code passthrough, nominal-error 200.

## Verification

`gofmt`, `go vet`, and `go test ./pkg/proxy/` pass. Reverting the 408 mapping to 500 makes both test functions fail, so the mapping is genuinely pinned.

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)